### PR TITLE
[JENKINS-34450] Work around deadlock in core

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -226,13 +226,18 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (forShutdown) {
                     return;
                 }
-                try {
-                    execution.interrupt(getExecutor().abortResult());
-                } catch (Exception x) {
-                    LOGGER.log(Level.WARNING, null, x);
-                }
-                getExecutor().recordCauseOfInterruption(WorkflowRun.this, listener);
-                printLater("term", "Click here to forcibly terminate running steps");
+                Timer.get().submit(new Runnable() {
+                    @Override public void run() {
+                        Executor executor = getExecutor();
+                        try {
+                            execution.interrupt(executor.abortResult());
+                        } catch (Exception x) {
+                            LOGGER.log(Level.WARNING, null, x);
+                        }
+                        executor.recordCauseOfInterruption(WorkflowRun.this, listener);
+                        printLater("term", "Click here to forcibly terminate running steps");
+                    }
+                });
             }
             @Override public boolean blocksRestart() {
                 return execution.blocksRestart();


### PR DESCRIPTION
[JENKINS-34450](https://issues.jenkins-ci.org/browse/JENKINS-34450)

While I think the proper fix is in core, it seems like this workaround may avoid the deadlock in the short term. If it seems to work, I can file a core PR, perhaps making `AsynchronousExecution` try to reuse the read/write lock from `Executor`.

@reviewbybees esp. @vivek