### PR TITLE
If LogRotator runs, we should also ask StashManager to clear all stashes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -557,9 +557,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @Override public void deleteArtifacts() throws IOException {
-        synchronized (this) {
-            super.deleteArtifacts();
-        }
+        super.deleteArtifacts();
         StashManager.clearAll(this);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -556,6 +556,13 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         }
     }
 
+    @Override public void deleteArtifacts() throws IOException {
+        synchronized (this) {
+            super.deleteArtifacts();
+        }
+        StashManager.clearAll(this);
+    }
+
     /**
      * Gets the associated execution state.
      * @return non-null after the flow has started, even after finished (but may be null temporarily when about to start, or if starting failed)


### PR DESCRIPTION
Just like `archive`d files would be deleted at this point, it makes sense to delete `stash`ed files. Normally they are deleted when the build finishes, but plugins can ask to hold onto them for longer.

@reviewbybees esp. @jtnord