### PR TITLE
Recover gracefully from a failure to load SCMCheckout.scm

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -675,6 +675,13 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             this.changelogFile = changelogFile;
             this.pollingBaseline = pollingBaseline;
         }
+        // TODO replace with Run.XSTREAM2.addCriticalField(SCMCheckout.class, "scm") when not @Restricted(NoExternalUse.class)
+        private Object readResolve() {
+            if (scm == null) {
+                throw new IllegalStateException("Unloadable scm field");
+            }
+            return this;
+        }
     }
 
     private static final class Owner extends FlowExecutionOwner {


### PR DESCRIPTION
A customer experiencing a failure to load the Subversion plugin after an update had a log file with errors like

```
… hudson.triggers.SCMTrigger$Runner runPolling
SEVERE: Failed to record SCM polling for org.jenkinsci.plugins.workflow.job.WorkflowJob@…[…]
java.lang.NullPointerException
        at org.jenkinsci.plugins.workflow.job.WorkflowJob.poll(WorkflowJob.java:509)
        at hudson.triggers.SCMTrigger$Runner.runPolling(SCMTrigger.java:526)
        at hudson.triggers.SCMTrigger$Runner.run(SCMTrigger.java:555)
        at …
```

By making `SCMCheckout` deserialization fail, not just its field, `RobustCollectionConverter` should kick in and exclude that entry automatically (making the change permanent if _Discard Old Data_ is selected).

@reviewbybees