### PR TITLE
Actually round-trip the disabled concurrent builds case.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/properties/DisableConcurrentBuildsJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/properties/DisableConcurrentBuildsJobPropertyTest.java
@@ -75,9 +75,10 @@ public class DisableConcurrentBuildsJobPropertyTest {
         assertTrue(roundTripDefault.isConcurrentBuild());
 
         WorkflowJob disabledCase = r.jenkins.createProject(WorkflowJob.class, "disableCase");
-        assertTrue(disabledCase.isConcurrentBuild());
+        disabledCase.setConcurrentBuild(false);
+        assertFalse(disabledCase.isConcurrentBuild());
 
         WorkflowJob roundTripDisabled = r.configRoundtrip(disabledCase);
-        assertTrue(roundTripDisabled.isConcurrentBuild());
+        assertFalse(roundTripDisabled.isConcurrentBuild());
     }
 }


### PR DESCRIPTION
While working on something else, I noticed that the default case and
disabled case sections in
`DisableConcurrentBuildsJobPropertyTest#configRoundTrip` were
identical. Which kinda defeated the point. So here we go - actually
roundtrip the disabled case.

cc @reviewbybees, esp @jglick