### PR TITLE
[JENKINS-34281] More general fix of CpsFlowExecution.suspendAll ACL bug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -52,6 +52,7 @@ import hudson.model.listeners.SCMListener;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
+import hudson.security.ACL;
 import hudson.util.Iterators;
 import hudson.util.NullStream;
 import hudson.util.PersistedList;
@@ -82,6 +83,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.lazy.BuildReference;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.model.queue.AsynchronousExecution;
+import jenkins.security.NotReallyRoleSensitiveCallable;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
@@ -705,11 +707,15 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (candidate != null && candidate.getParent().getFullName().equals(job) && candidate.getId().equals(id)) {
                     run = candidate;
                 } else {
-                    Jenkins jenkins = Jenkins.getInstance();
+                    final Jenkins jenkins = Jenkins.getInstance();
                     if (jenkins == null) {
                         throw new IOException("Jenkins is not running"); // do not use Jenkins.getActiveInstance() as that is an ISE
                     }
-                    WorkflowJob j = jenkins.getItemByFullName(job, WorkflowJob.class);
+                    WorkflowJob j = ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<WorkflowJob,IOException>() {
+                        @Override public WorkflowJob call() throws IOException {
+                            return jenkins.getItemByFullName(job, WorkflowJob.class);
+                        }
+                    });
                     if (j == null) {
                         throw new IOException("no such WorkflowJob " + job);
                     }


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/workflow-cps-plugin/pull/19 (harmless to have both).

From the system log while using 1.14.1, the following was found:

```
… WARNING o.j.p.w.flow.FlowExecutionList$1#computeNext: Failed to load Owner[…/…:null]. Unregisteringjava.io.IOException: no such WorkflowJob …
    at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.run(WorkflowRun.java:701)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:713)
    at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:63)
    at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:55)
    at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
    at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
    at org.jenkinsci.plugins.workflow.support.steps.input.InputAction.loadExecutions(InputAction.java:57)
    at org.jenkinsci.plugins.workflow.support.steps.input.InputAction.getExecutions(InputAction.java:133)
    at com.cloudbees.workflow.rest.external.RunExt.isPendingInput(RunExt.java:386)
    at com.cloudbees.workflow.rest.external.RunExt.createOld(RunExt.java:327)
    at com.cloudbees.workflow.rest.external.RunExt.create(RunExt.java:303)
    at com.cloudbees.workflow.rest.external.JobExt.create(JobExt.java:126)
    at com.cloudbees.workflow.rest.endpoints.JobAPI.doRuns(JobAPI.java:68)
```

for a job which _did_ exist. The most plausible explanation seems to be that the named job was not visible as the user browsing the stage view in this HTTP request.

The earlier case was reported [here](https://issues.jenkins-ci.org/browse/JENKINS-34281?focusedCommentId=260500&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-260500). I am no longer able to reproduce that, unfortunately, and am unclear on the mechanism: a given `Owner` in `FlowExecutionList.runningTasks` was either

* created by starting a build during this session, in which case the `WorkflowRun run` field would be set in the initializer; or
* deserialized in `runningTasks`, in which case `FlowExecutionList.ItemListenerImpl.onLoaded` should have forced `run` to be resolved and cached (as `SYSTEM`) during startup, before any HTTP request servicing began

In either case, `run()` should immediately return the cached field, ignoring `Jenkins.getAuthentication()`. Nonetheless, I suspect there are some corner cases where this does not happen, and there are many other places where `FlowExecutionOwner.get()` may be called (which _probably_ are running as `SYSTEM` but I am not positive), and so it is safer to be sure that `SYSTEM` is used to resolve the job if it exists. Harmless to wrap in `impersonate` even if we are already running as `SYSTEM`.

@reviewbybees