### PR TITLE
Indicating in the build log when a restart occurred

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -62,6 +62,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -487,7 +488,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 try {
                     OutputStream logger = new FileOutputStream(getLogFile(), true);
                     listener = new StreamBuildListener(logger, Charset.defaultCharset());
-                    listener.getLogger().println("Resuming build");
+                    listener.getLogger().println("Resuming build at " + new Date() + " after Jenkins restart");
                 } catch (IOException x) {
                     LOGGER.log(Level.WARNING, null, x);
                     listener = new StreamBuildListener(new NullStream());


### PR DESCRIPTION
Show a timestamp when resuming a build. Generally useful, and if backported to 1.14.x, would make it easier to diagnose [JENKINS-22767](https://issues.jenkins-ci.org/browse/JENKINS-22767) (fixed in the baseline of 2.x plugins).

@reviewbybees