### PR TITLE
[FIXED JENKINS-37872] Add WorkflowRun.getCulprits()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,44 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.5.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.2</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>2.5.2</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-support</artifactId>
             <version>1.15</version>

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -39,23 +39,26 @@ import hudson.security.Permission;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.GitStep;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
@@ -71,6 +74,7 @@ public class WorkflowRunTest {
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
 
     @Test public void basics() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
@@ -274,6 +278,76 @@ public class WorkflowRunTest {
         iba = b2.getAction(InterruptedBuildAction.class);
         assertNotNull(iba);
         assertEquals(Collections.emptyList(), iba.getCauses());
+    }
+
+    private void assertCulprits(WorkflowRun b, String... expectedIds) {
+        Set<String> actual = new TreeSet<>();
+        for (User u : b.getCulprits()) {
+            actual.add(u.getId());
+        }
+        assertEquals(actual, new TreeSet<>(Arrays.asList(expectedIds)));
+    }
+
+    private void updateJenkinsfileWithCommitter(String committerName, String committerEmail, String jenkinsfileText)
+            throws Exception {
+        sampleRepo.git("config", "user.name", committerName);
+        sampleRepo.git("config", "user.email", committerEmail);
+        sampleRepo.write("Jenkinsfile", jenkinsfileText);
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=testing");
+    }
+
+    @Issue("JENKINS-37872")
+    @Test
+    public void culprits() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+
+        sampleRepo.init();
+
+        p.setDefinition(new CpsScmFlowDefinition(new GitStep(sampleRepo.toString()).createSCM(), "Jenkinsfile"));
+
+        // 1st build, successful, no culprits. No changesets at all, actually, since it's the first build!
+        updateJenkinsfileWithCommitter("alice", "alice@example.com", "echo 'commit by alice'; echo 'Build successful'");
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        // 2nd build
+        updateJenkinsfileWithCommitter("bob", "bob@example.com", "echo 'commit by bob'; currentBuild.result = 'FAILURE'");
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b2));
+        assertCulprits(b2, "bob");
+
+        // 3rd build. bob continues to be in culprit
+        updateJenkinsfileWithCommitter("charlie", "charlie@example.com", "echo 'commit by charlie'; currentBuild.result = 'FAILURE'");
+        WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b3));
+        assertCulprits(b3, "bob", "charlie");
+
+        // 4th build, unstable. culprit list should continue
+        updateJenkinsfileWithCommitter("dave", "dave@example.com", "echo 'commit by dave'; currentBuild.result = 'UNSTABLE'");
+        WorkflowRun b4 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatus(Result.UNSTABLE, r.waitForCompletion(b4));
+        assertCulprits(b4, "bob", "charlie", "dave");
+
+        // 5th build, unstable, just a re-run of the previous one.
+        WorkflowRun b5 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatus(Result.UNSTABLE, r.waitForCompletion(b5));
+        assertCulprits(b5, "bob", "charlie", "dave");
+
+        // 6th build, unstable. culprit list should continue
+        updateJenkinsfileWithCommitter("eve", "eve@example.com", "echo 'commit by eve'; currentBuild.result = 'UNSTABLE'");
+        WorkflowRun b6 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatus(Result.UNSTABLE, r.waitForCompletion(b6));
+        assertCulprits(b6, "bob", "charlie", "dave", "eve");
+
+        // 7th build, success, accumulation continues up to this point
+        updateJenkinsfileWithCommitter("fred", "fred@example.com", "echo 'commit by fred'; echo 'Build successful'");
+        WorkflowRun b7 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertCulprits(b7, "bob", "charlie", "dave", "eve", "fred");
+
+        // 8th build, back to culprits just containing who ever committed to this one specific build.
+        updateJenkinsfileWithCommitter("george", "george@example.com", "echo 'commit by george'; echo 'Build successful'");
+        WorkflowRun b8 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertCulprits(b8, "george");
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -61,6 +61,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
+
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -299,6 +301,8 @@ public class WorkflowRunTest {
     @Issue("JENKINS-37872")
     @Test
     public void culprits() throws Exception {
+        // TODO: Eventually change this to override GIT_COMMITTER_NAME etc. For now, skip if that's set.
+        Assume.assumeTrue("GIT_COMMITTER_NAME env var not set", System.getenv("GIT_COMMITTER_NAME") == null);
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -290,11 +290,10 @@ public class WorkflowRunTest {
 
     private void updateJenkinsfileWithCommitter(String committerName, String committerEmail, String jenkinsfileText)
             throws Exception {
-        sampleRepo.git("config", "user.name", committerName);
-        sampleRepo.git("config", "user.email", committerEmail);
         sampleRepo.write("Jenkinsfile", jenkinsfileText);
         sampleRepo.git("add", "Jenkinsfile");
-        sampleRepo.git("commit", "--all", "--message=testing");
+        sampleRepo.git("-c", "user.name='" + committerName + "'", "-c", "user.email='" + committerEmail + "'",
+                "commit", "--all", "--message=testing");
     }
 
     @Issue("JENKINS-37872")

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -285,7 +285,7 @@ public class WorkflowRunTest {
         for (User u : b.getCulprits()) {
             actual.add(u.getId());
         }
-        assertEquals(actual, new TreeSet<>(Arrays.asList(expectedIds)));
+        assertEquals(TreeSet<>(Arrays.asList(expectedIds), actual));
     }
 
     private void updateJenkinsfileWithCommitter(String committerName, String committerEmail, String jenkinsfileText)

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -285,7 +285,7 @@ public class WorkflowRunTest {
         for (User u : b.getCulprits()) {
             actual.add(u.getId());
         }
-        assertEquals(TreeSet<>(Arrays.asList(expectedIds), actual));
+        assertEquals(new TreeSet<>(Arrays.asList(expectedIds)), actual);
     }
 
     private void updateJenkinsfileWithCommitter(String committerName, String committerEmail, String jenkinsfileText)


### PR DESCRIPTION
[JENKINS-37872](https://issues.jenkins-ci.org/browse/JENKINS-37872)
- [x] Add a basic `getCulprits()` with test.
- [ ] Decide if we want to emulate `AbstractBuild.upstreamCulprits`.
- [ ] Determine if there's a way to limit culprits to just the repo the `Jenkinsfile` comes from if so desired?

FWIW: `upstreamCulprits` is built on top of `AbstractBuild.getDependencyChanges(AbstractBuild)`, which itself is dependent on `FingerprintAction` usage and `AbstractBuild.DependencyChange`, which is a whole complicated pile o' logic. So...good question as to whether that's functionality we want to emulate.

And as of right now, I honestly can't tell if there's a viable way to restrict the culprits to the SCM checkout that provided the `Jenkinsfile` - the `ChangeLogSet`s don't seem to preserve their origin SCM information...

cc @reviewbybees esp @jglick 
