### PR TITLE
[JENKINS-27394] Collapsible sections in log

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -885,7 +885,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         String prefix = getLogPrefix(node);
         String text = node.getDisplayFunctionName();
         if (node instanceof BlockStartNode) {
-            text += " (" + ShowHideNote.encodeTo(node.getId(), true, "show") + "/" + ShowHideNote.encodeTo(node.getId(), false, "hide") + ")";
+            text += " (" + ShowHideNote.create(node.getId()) + ")";
         }
         if (prefix != null) {
             wfLogger.log(String.format("[%s] %s", prefix, text));

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -61,6 +61,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -94,8 +95,11 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.console.NestingNote;
+import org.jenkinsci.plugins.workflow.job.console.ShowHideNote;
 import org.jenkinsci.plugins.workflow.job.console.WorkflowConsoleLogger;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -370,14 +374,17 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 AnnotatedLargeText<? extends FlowNode> logText = la.getLogText();
                 try {
                     long old = entry.getValue();
-                    OutputStream logger;
 
                     String prefix = getLogPrefix(node);
+                    List<String> nesting = getNesting(node);
+                    String encodedNesting = new NestingNote(nesting).encode();
+                    String linePrefix;
                     if (prefix != null) {
-                        logger = new LogLinePrefixOutputFilter(listener.getLogger(), "[" + prefix + "] ");
+                        linePrefix = encodedNesting + "[" + prefix + "] ";
                     } else {
-                        logger = listener.getLogger();
+                        linePrefix = encodedNesting;
                     }
+                    OutputStream logger = new LogLinePrefixOutputFilter(listener.getLogger(), linePrefix);
 
                     try {
                         long revised = writeRawLogTo(logText, old, logger);
@@ -451,6 +458,37 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 });
             }
             return logPrefixCache.getUnchecked(node).orNull();
+        }
+    }
+
+    @GuardedBy("completed")
+    private transient LoadingCache<FlowNode,List<String>> nestingCache;
+    private @Nonnull List<String> getNesting(FlowNode node) {
+        // TODO could also use FlowScanningUtils.fetchEnclosingBlocks(node) but this would not let us cache intermediate results
+        synchronized (completed) {
+            if (nestingCache == null) {
+                nestingCache = CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<FlowNode,List<String>>() {
+                    @Override public @Nonnull List<String> load(FlowNode node) {
+                        if (node instanceof BlockEndNode) {
+                            return getNesting(((BlockEndNode) node).getStartNode());
+                        } else {
+                            List<FlowNode> parents = node.getParents();
+                            if (parents.isEmpty()) { // FlowStartNode
+                                return Collections.emptyList();
+                            }
+                            List<String> parent = getNesting(parents.get(0)); // multiple parents is only for BlockEndNode after parallel
+                            if (node instanceof BlockStartNode) {
+                                List<String> appended = new ArrayList<>(parent);
+                                appended.add(node.getId());
+                                return appended;
+                            } else { // AtomNode
+                                return parent;
+                            }
+                        }
+                    }
+                });
+            }
+            return nestingCache.getUnchecked(node);
         }
     }
 
@@ -833,12 +871,26 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     private void logNodeMessage(FlowNode node) {
+        List<String> nesting = getNesting(node);
+        if (!nesting.isEmpty() && nesting.get(nesting.size() - 1).equals(node.getId())) {
+            // For a BlockStartNode, we do not want to hide itself.
+            nesting = new ArrayList<>(nesting.subList(0, nesting.size() - 1));
+        }
+        try {
+            listener.annotate(new NestingNote(nesting));
+        } catch (IOException x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
         WorkflowConsoleLogger wfLogger = new WorkflowConsoleLogger(listener);
         String prefix = getLogPrefix(node);
+        String text = node.getDisplayFunctionName();
+        if (node instanceof BlockStartNode) {
+            text += " (" + ShowHideNote.encodeTo(node.getId(), true, "show") + "/" + ShowHideNote.encodeTo(node.getId(), false, "hide") + ")";
+        }
         if (prefix != null) {
-            wfLogger.log(String.format("[%s] %s", prefix, node.getDisplayFunctionName()));
+            wfLogger.log(String.format("[%s] %s", prefix, text));
         } else {
-            wfLogger.log(node.getDisplayFunctionName());
+            wfLogger.log(text);
         }
         // Flushing to keep logs printed in order as much as possible. The copyLogs method uses
         // LargeText and possibly LogLinePrefixOutputFilter. Both of these buffer and flush, causing strange

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/NestingNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/NestingNote.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.job.console;
+
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+import hudson.model.Run;
+import java.util.List;
+
+/**
+ * Encodes the block-scoped nesting of a step.
+ */
+public class NestingNote extends ConsoleNote<Run<?,?>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> nesting;
+
+    public NestingNote(List<String> nesting) {
+        this.nesting = nesting;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override public ConsoleAnnotator annotate(Run<?,?> context, MarkupText text, int charPos) {
+        StringBuilder b = new StringBuilder("<span class=\"");
+        for (int i = 0; i < nesting.size(); i++) {
+            if (i > 0) {
+                b.append(' ');
+            }
+            b.append("pipeline-sect-").append(nesting.get(i));
+        }
+        b.append("\">");
+        text.addMarkup(0, text.length(), b.toString(), "</span>");
+        return null;
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
@@ -24,6 +24,8 @@
 
 package org.jenkinsci.plugins.workflow.job.console;
 
+import hudson.Extension;
+import hudson.console.ConsoleAnnotationDescriptor;
 import hudson.console.HyperlinkNote;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -48,7 +50,6 @@ public class ShowHideNote extends HyperlinkNote {
     }
 
     private final String id;
-    // TODO better to have a single link that toggles (requires looking up current state, as below)
     private final boolean show;
 
     private ShowHideNote(String id, boolean show, int length) {
@@ -58,8 +59,9 @@ public class ShowHideNote extends HyperlinkNote {
     }
 
     @Override protected String extraAttributes() {
-        // TODO look up any existing rule via .selectorText and change its .style.display (but how can be package this JS into an adjunct?)
-        return " onclick=\"var ss = document.styleSheets[0]; ss.insertRule('.pipeline-sect-" + id + " {display: " + (show ? "inline" : "none") + "}', ss.rules.length); return false\"";
+        return " onclick=\"showHidePipelineSection('" + id + "', " + show + "); return false\"";
     }
+
+    @Extension public static class DescriptorImpl extends ConsoleAnnotationDescriptor {}
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
@@ -39,9 +39,10 @@ public class ShowHideNote extends HyperlinkNote {
     private static final Logger LOGGER = Logger.getLogger(ShowHideNote.class.getName());
     private static final long serialVersionUID = 1L;
 
-    public static String encodeTo(String id, boolean show, String text) {
+    public static String create(String id) {
+        String text = "hide";
         try {
-            return new ShowHideNote(id, show, text.length()).encode() + text;
+            return new ShowHideNote(id, text.length()).encode() + text;
         } catch (IOException e) {
             // impossible, but don't make this a fatal problem
             LOGGER.log(Level.WARNING, "Failed to serialize " + ShowHideNote.class, e);
@@ -50,16 +51,14 @@ public class ShowHideNote extends HyperlinkNote {
     }
 
     private final String id;
-    private final boolean show;
 
-    private ShowHideNote(String id, boolean show, int length) {
+    private ShowHideNote(String id, int length) {
         super("#", length);
         this.id = id;
-        this.show = show;
     }
 
     @Override protected String extraAttributes() {
-        return " onclick=\"showHidePipelineSection('" + id + "', " + show + "); return false\"";
+        return " id=\"show-hide-" + id + "\" onclick=\"showHidePipelineSection('" + id + "'); return false\"";
     }
 
     @Extension public static class DescriptorImpl extends ConsoleAnnotationDescriptor {}

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.job.console;
+
+import hudson.console.HyperlinkNote;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Shows or hides a block by nesting.
+ */
+public class ShowHideNote extends HyperlinkNote {
+
+    private static final Logger LOGGER = Logger.getLogger(ShowHideNote.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    public static String encodeTo(String id, boolean show, String text) {
+        try {
+            return new ShowHideNote(id, show, text.length()).encode() + text;
+        } catch (IOException e) {
+            // impossible, but don't make this a fatal problem
+            LOGGER.log(Level.WARNING, "Failed to serialize " + ShowHideNote.class, e);
+            return text;
+        }
+    }
+
+    private final String id;
+    // TODO better to have a single link that toggles (requires looking up current state, as below)
+    private final boolean show;
+
+    private ShowHideNote(String id, boolean show, int length) {
+        super("#", length);
+        this.id = id;
+        this.show = show;
+    }
+
+    @Override protected String extraAttributes() {
+        // TODO look up any existing rule via .selectorText and change its .style.display (but how can be package this JS into an adjunct?)
+        return " onclick=\"var ss = document.styleSheets[0]; ss.insertRule('.pipeline-sect-" + id + " {display: " + (show ? "inline" : "none") + "}', ss.rules.length); return false\"";
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/ShowHideNote.java
@@ -58,7 +58,7 @@ public class ShowHideNote extends HyperlinkNote {
     }
 
     @Override protected String extraAttributes() {
-        return " id=\"show-hide-" + id + "\" onclick=\"showHidePipelineSection('" + id + "'); return false\"";
+        return " show-hide-id=\"" + id + "\" onclick=\"showHidePipelineSection(this); return false\"";
     }
 
     @Extension public static class DescriptorImpl extends ConsoleAnnotationDescriptor {}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
@@ -22,10 +22,18 @@
  * THE SOFTWARE.
  */
 
-// TODO better to have a single link that toggles (requires looking up current state, as below)
-function showHidePipelineSection(id, show) {
+// TODO infer section from the event source perhaps?
+function showHidePipelineSection(id) {
+    var link = document.getElementById('show-hide-' + id)
+    var display
+    if (link.textContent === 'hide') {
+        display = 'none'
+        link.textContent = 'show'
+    } else {
+        display = 'inline'
+        link.textContent = 'hide'
+    }
     var sect = '.pipeline-sect-' + id
-    var display = show ? 'inline' : 'none'
     var ss = document.styleSheets[0]
     for (var i = 0; i < ss.rules.length; i++) {
         if (ss.rules[i].selectorText === sect) {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
@@ -24,8 +24,15 @@
 
 // TODO better to have a single link that toggles (requires looking up current state, as below)
 function showHidePipelineSection(id, show) {
+    var sect = '.pipeline-sect-' + id
+    var display = show ? 'inline' : 'none'
     var ss = document.styleSheets[0]
-    // TODO look up any existing rule via .selectorText and change its .style.display
+    for (var i = 0; i < ss.rules.length; i++) {
+        if (ss.rules[i].selectorText === sect) {
+            ss.rules[i].style.display = display
+            return
+        }
+    }
     // TODO order rules, so that hiding and reshowing a high-level section will restore expansion of a lower-level section
-    ss.insertRule('.pipeline-sect-' + id + ' {display: ' + (show ? 'inline' : 'none') + '}', ss.rules.length)
+    ss.insertRule(sect + ' {display: ' + display + '}', ss.rules.length)
 }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
@@ -1,0 +1,31 @@
+/* 
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// TODO better to have a single link that toggles (requires looking up current state, as below)
+function showHidePipelineSection(id, show) {
+    var ss = document.styleSheets[0]
+    // TODO look up any existing rule via .selectorText and change its .style.display
+    // TODO order rules, so that hiding and reshowing a high-level section will restore expansion of a lower-level section
+    ss.insertRule('.pipeline-sect-' + id + ' {display: ' + (show ? 'inline' : 'none') + '}', ss.rules.length)
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
@@ -23,8 +23,8 @@
  */
 
 // TODO infer section from the event source perhaps?
-function showHidePipelineSection(id) {
-    var link = document.getElementById('show-hide-' + id)
+function showHidePipelineSection(link) {
+    var id = link.getAttribute('show-hide-id')
     var display
     if (link.textContent === 'hide') {
         display = 'none'

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/ShowHideNote/script.js
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 
-// TODO infer section from the event source perhaps?
 function showHidePipelineSection(link) {
     var id = link.getAttribute('show-hide-id')
     var display


### PR DESCRIPTION
[JENKINS-27394](https://issues.jenkins-ci.org/browse/JENKINS-27394)

Downstream of #20.

I initially thought to add visual bounding boxes, as the Collapsing Console Sections plugin does. But this would not work with `parallel` steps at all, and it seemed clumsy to show bounding boxes unless you were inside a branch.

A more radical alternative would be to _never_ show multiple branches interleaved at all, and have a special control at the start of a `parallel` branch allowing you to select which branch to display. This would usually be fine, but there are also some cases where you actually want to know what happened in which order; Pipeline captures this information and it would be a shame to throw it away. The likely replacement would be to bake in the equivalent of the `timestamper` wrapper so you could manually compare timestamps between branches in cases where this was important for debugging something.

Note a little log cleanup in https://github.com/jenkinsci/workflow-support-plugin/pull/10. The longer-term plan is to interleave all output into a single log file internally, with flow node (and perhaps timestamp) metadata captured at point of origin, and various visualizations like the annotated console log able to display the data however they prefer.

@reviewbybees