### PR TITLE
[JENKINS-33821] Pipeline jobs can't be disabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.23-SNAPSHOT</jenkins.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -30,6 +30,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.cli.declarative.CLIMethod;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.Action;
@@ -52,6 +53,7 @@ import hudson.model.RunMap;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
+import hudson.model.listeners.ItemListener;
 import hudson.model.listeners.SCMListener;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskFuture;
@@ -83,6 +85,7 @@ import jenkins.model.BlockedBecauseOfBuildInProgress;
 
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+import jenkins.model.DisableableJobMixIn;
 import jenkins.model.lazy.LazyBuildMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import jenkins.util.TimeDuration;
@@ -94,14 +97,12 @@ import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobP
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
-public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements BuildableItem, LazyBuildMixIn.LazyLoadingJob<WorkflowJob,WorkflowRun>, ParameterizedJobMixIn.ParameterizedJob, TopLevelItem, Queue.FlyweightTask, SCMTriggerItem {
+public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements BuildableItem, LazyBuildMixIn.LazyLoadingJob<WorkflowJob,WorkflowRun>, ParameterizedJobMixIn.ParameterizedJob, TopLevelItem, Queue.FlyweightTask, SCMTriggerItem, DisableableJobMixIn.DisableableJob {
 
     private FlowDefinition definition;
     /** @deprecated - use {@link PipelineTriggersJobProperty} */
@@ -118,9 +119,18 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
      */
     private transient volatile Map<String,SCMRevisionState> pollingBaselines;
 
+    /**
+     * True to suspend new builds.
+     */
+    private boolean disabled;
+
     public WorkflowJob(ItemGroup parent, String name) {
         super(parent, name);
         buildMixIn = createBuildMixIn();
+    }
+
+    @Override public boolean isDisabled() {
+        return disabled;
     }
 
     @Override public void onCreatedFromScratch() {
@@ -180,6 +190,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         definition = req.bindJSON(FlowDefinition.class, json.getJSONObject("definition"));
         authToken = hudson.model.BuildAuthorizationToken.create(req);
 
+        makeDisabled(json.optBoolean("disable"));
+
         if (req.getParameter("hasCustomQuietPeriod") != null) {
             quietPeriod = Integer.parseInt(req.getParameter("quiet_period"));
         } else {
@@ -195,7 +207,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public boolean isBuildable() {
-        return true; // why not?
+        return !isDisabled();
     }
 
     @Override protected RunMap<WorkflowRun> _getRuns() {
@@ -239,6 +251,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public Queue.Executable createExecutable() throws IOException {
+	if (isDisabled())
+	    return null;
         return buildMixIn.newBuild();
     }
 
@@ -547,7 +561,12 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
 
     @Override public PollingResult poll(TaskListener listener) {
         // TODO call SCMPollListener
-        WorkflowRun lastBuild = getLastBuild();
+        if (!isBuildable()) {
+            listener.getLogger().println("project is disabled, skipping polling");
+	    return PollingResult.NO_CHANGES;
+        }
+
+	WorkflowRun lastBuild = getLastBuild();
         if (lastBuild == null) {
             listener.getLogger().println("no previous build to compare to");
             // Note that we have no equivalent of AbstractProject.NoSCM because without an initial build we do not know if this project has any SCM at all.
@@ -632,7 +651,43 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         }
     }
 
+    private void makeDisabled(boolean b) throws IOException {
+        if (disabled == b)
+            return;
+        this.disabled = b;
+        if (b)
+            Jenkins.getInstance().getQueue().cancel(this);
+        save();
+    }
+
+    @Override
+    public void disable() throws IOException {
+        makeDisabled(true);
+    }
+
+    @Override
+    public void enable() throws IOException {
+        makeDisabled(false);
+    }
+
+    @CLIMethod(name="disable-job")
+    @RequirePOST
+    public HttpResponse doDisable() throws IOException, ServletException {
+        checkPermission(CONFIGURE);
+        makeDisabled(true);
+	    return new HttpRedirect(".");
+    }
+
+    @CLIMethod(name="enable-job")
+    @RequirePOST
+    public HttpResponse doEnable() throws IOException, ServletException {
+	    checkPermission(CONFIGURE);
+	    makeDisabled(false);
+	    return new HttpRedirect(".");
+    }
+
     @Override protected void performDelete() throws IOException, InterruptedException {
+	makeDisabled(true);
         super.performDelete();
         // TODO call SCM.processWorkspaceBeforeDeletion
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/configure-entries.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/configure-entries.jelly
@@ -25,6 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
+    <p:config-disableBuild/>
     <p:config-quietPeriod/>
 
     <!-- pseudo-trigger to configure URL to trigger builds remotely. -->

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
@@ -25,6 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:p="/lib/hudson/project" xmlns:t="/lib/hudson">
+    <st:include page="makeDisabled.jelly"/>
     <p:projectActionFloatingBox/>
     <table style="margin-top: 1em; margin-left:1em;">
         <!-- TODO display prominentActions -->

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/makeDisabled.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/makeDisabled.jelly
@@ -1,0 +1,48 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt, Tom Huybrechts, id:cactusman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <j:choose>
+    <j:when test="${it.disabled}">
+      <div class="warning">
+        <form method="post" id='enable-project' action="enable">
+          ${%This pipeline is currently disabled}
+          <l:hasPermission permission="${it.CONFIGURE}">
+            <f:submit value="${%Enable}" />
+          </l:hasPermission>
+        </form>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <div align="right">
+        <form method="post" id="disable-project" action="disable">
+          <l:hasPermission permission="${it.CONFIGURE}">
+            <f:submit value="${%Disable Pipeline}" />
+          </l:hasPermission>
+        </form>
+      </div>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>


### PR DESCRIPTION
UPDATE: Based on some feedback on the Jenkins core change I have posted an alternative implementation: https://github.com/jenkinsci/workflow-job-plugin/pull/23

I'm not sure if this is the right approach to take, so I'm posting this in hopes that someone can point me in a better direction if this is wrong.

This change would depend on https://github.com/jenkinsci/jenkins/pull/2543 See some notes there about what I'm trying to accomplish.

Presumably this would need to wait some time after the necessary change to Jenkins core to be accepted to avoid bumping the minimum Jenkins version too high? Also, until the core change goes in the automated tests run by Jenkins will fail.

I took all of my queues on what needed to be implemented based on what disable-specific logic I could see in AbstractProject. Some manual testing seemed to show this works, but I'm not sure I did this correctly. I can make any suggested changes.