### PR TITLE
[JENKINS-33821] Pipeline jobs can't be disabled (alternate)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -661,11 +661,16 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     private void makeDisabled(boolean b) throws IOException {
-        if (disabled == b)
+        if (disabled == b) {
             return;
+	}
         this.disabled = b;
-        if (b)
-            Jenkins.getInstance().getQueue().cancel(this);
+        if (b) {
+	    Jenkins instance = Jenkins.getInstance();
+	    if (instance != null) {
+		instance.getQueue().cancel(this);
+	    }
+	}
         save();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -35,6 +35,7 @@ import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.Action;
 import hudson.model.BuildableItem;
+import hudson.model.BallColor;
 import hudson.model.Cause;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -140,6 +141,19 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
      */
     public boolean isDisabled() {
         return disabled;
+    }
+
+    /*
+     * Overrides Job.getIconColor() to add logic for disabled Jobs.
+     * Starting in Jenkins core version TODO Job.getIconColor() supports
+     * disabled jobs in core and this override can be removed.
+     */
+    @Override public BallColor getIconColor() {
+        if(isDisabled()) {
+            return isBuilding() ? BallColor.DISABLED_ANIME : BallColor.DISABLED;
+        } else {
+            return super.getIconColor();
+        }
     }
 
     @Override public void onCreatedFromScratch() {
@@ -260,8 +274,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public Queue.Executable createExecutable() throws IOException {
-	if (isDisabled())
-	    return null;
+        if (isDisabled())
+            return null;
         return buildMixIn.newBuild();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -30,6 +30,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.cli.declarative.CLIMethod;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.model.Action;
@@ -52,6 +53,7 @@ import hudson.model.RunMap;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.model.TopLevelItemDescriptor;
+import hudson.model.listeners.ItemListener;
 import hudson.model.listeners.SCMListener;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskFuture;
@@ -94,9 +96,7 @@ import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobP
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -118,9 +118,28 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
      */
     private transient volatile Map<String,SCMRevisionState> pollingBaselines;
 
+    /**
+     * True to suspend new builds.
+     */
+    private boolean disabled;
+
     public WorkflowJob(ItemGroup parent, String name) {
         super(parent, name);
         buildMixIn = createBuildMixIn();
+    }
+
+    /*
+     * @Overrides method in Job<?, ?> added in Jenkins core version TODO
+     */
+    public boolean supportsDisable() {
+        return true;
+    }
+
+    /*
+     * @Overrides method in Job<?, ?> added in Jenkins core version TODO
+     */
+    public boolean isDisabled() {
+        return disabled;
     }
 
     @Override public void onCreatedFromScratch() {
@@ -180,6 +199,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         definition = req.bindJSON(FlowDefinition.class, json.getJSONObject("definition"));
         authToken = hudson.model.BuildAuthorizationToken.create(req);
 
+        makeDisabled(json.optBoolean("disable"));
+
         if (req.getParameter("hasCustomQuietPeriod") != null) {
             quietPeriod = Integer.parseInt(req.getParameter("quiet_period"));
         } else {
@@ -195,7 +216,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public boolean isBuildable() {
-        return true; // why not?
+        return !isDisabled();
     }
 
     @Override protected RunMap<WorkflowRun> _getRuns() {
@@ -239,6 +260,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public Queue.Executable createExecutable() throws IOException {
+	if (isDisabled())
+	    return null;
         return buildMixIn.newBuild();
     }
 
@@ -547,7 +570,12 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
 
     @Override public PollingResult poll(TaskListener listener) {
         // TODO call SCMPollListener
-        WorkflowRun lastBuild = getLastBuild();
+        if (!isBuildable()) {
+            listener.getLogger().println("project is disabled, skipping polling");
+	    return PollingResult.NO_CHANGES;
+        }
+
+	WorkflowRun lastBuild = getLastBuild();
         if (lastBuild == null) {
             listener.getLogger().println("no previous build to compare to");
             // Note that we have no equivalent of AbstractProject.NoSCM because without an initial build we do not know if this project has any SCM at all.
@@ -632,7 +660,47 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         }
     }
 
+    private void makeDisabled(boolean b) throws IOException {
+        if (disabled == b)
+            return;
+        this.disabled = b;
+        if (b)
+            Jenkins.getInstance().getQueue().cancel(this);
+        save();
+    }
+
+    /*
+     * @Overrides method added to Job<?, ?> in Jenkins core version TODO
+     */
+    public void disable() throws IOException {
+        makeDisabled(true);
+    }
+
+    /*
+     * @Overrides method added to Job<?, ?> in Jenkins core version TODO
+     */
+    public void enable() throws IOException {
+        makeDisabled(false);
+    }
+
+    @CLIMethod(name="disable-job")
+    @RequirePOST
+    public HttpResponse doDisable() throws IOException, ServletException {
+        checkPermission(CONFIGURE);
+        makeDisabled(true);
+	    return new HttpRedirect(".");
+    }
+
+    @CLIMethod(name="enable-job")
+    @RequirePOST
+    public HttpResponse doEnable() throws IOException, ServletException {
+	    checkPermission(CONFIGURE);
+	    makeDisabled(false);
+	    return new HttpRedirect(".");
+    }
+
     @Override protected void performDelete() throws IOException, InterruptedException {
+	makeDisabled(true);
         super.performDelete();
         // TODO call SCM.processWorkspaceBeforeDeletion
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/Messages.properties
@@ -1,3 +1,5 @@
 WorkflowJob.Description=Orchestrates long-running activities that can span multiple build slaves. Suitable for \
   building pipelines (formerly known as workflows) and/or organizing complex activities that do not easily fit in \
   free-style job type.
+CLI.disable-job.shortDescription=Disables a job.
+CLI.enable-job.shortDescription=Enables a job.

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/configure-entries.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/configure-entries.jelly
@@ -25,6 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
+    <p:config-disableBuild/>
     <p:config-quietPeriod/>
 
     <!-- pseudo-trigger to configure URL to trigger builds remotely. -->

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
@@ -25,6 +25,7 @@
   -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:p="/lib/hudson/project" xmlns:t="/lib/hudson">
+    <st:include page="makeDisabled.jelly"/>
     <p:projectActionFloatingBox/>
     <table style="margin-top: 1em; margin-left:1em;">
         <!-- TODO display prominentActions -->

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/makeDisabled.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/makeDisabled.jelly
@@ -1,0 +1,48 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Erik Ramfelt, Tom Huybrechts, id:cactusman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+  <j:choose>
+    <j:when test="${it.disabled}">
+      <div class="warning">
+        <form method="post" id='enable-project' action="enable">
+          ${%This pipeline is currently disabled}
+          <l:hasPermission permission="${it.CONFIGURE}">
+            <f:submit value="${%Enable}" />
+          </l:hasPermission>
+        </form>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <div align="right">
+        <form method="post" id="disable-project" action="disable">
+          <l:hasPermission permission="${it.CONFIGURE}">
+            <f:submit value="${%Disable Pipeline}" />
+          </l:hasPermission>
+        </form>
+      </div>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -142,6 +142,11 @@ public class WorkflowRunTest {
         assertFalse(b1.hasntStartedYet());
         assertColor(b1, BallColor.BLUE);
 
+        // after disabling the project icon should change
+        p.disable();
+        assertSame(BallColor.DISABLED, p.getIconColor());
+        p.enable();
+
         // get another one going
         q = p.scheduleBuild2(0);
         WorkflowRun b2 = q.getStartCondition().get();
@@ -150,6 +155,11 @@ public class WorkflowRunTest {
         // initial state should be blinking blue because the last one was blue
         assertFalse(b2.hasntStartedYet());
         assertColor(b2, BallColor.BLUE_ANIME);
+
+        // disabling while a job is running should show animated disable icon
+        p.disable();
+        assertSame(BallColor.DISABLED_ANIME, p.getIconColor());
+        p.enable();
 
         SemaphoreStep.waitForStart("wait/2", b2);
 
@@ -165,6 +175,7 @@ public class WorkflowRunTest {
         assertFalse(b2.hasntStartedYet());
         assertColor(b2, BallColor.BLUE);
     }
+
     private void assertColor(WorkflowRun b, BallColor color) throws IOException {
         assertSame(color, b.getIconColor());
         assertSame(color, b.getParent().getIconColor());


### PR DESCRIPTION
This goes together with the Jenkins core change in https://github.com/jenkinsci/jenkins/pull/2544. While the core change is related, it is not required to use the disable/enable functionality in this diff. I have tested this change with Jenkins core 1.642.3 (and with the pull request above) and disable/enable seems to work, including cancelling queued jobs, updating the job BallColor, blocking SCM polling, and blocking cron triggers. The core functionality of "don't do builds if a job is disabled" seems to work as long as WorkflowJob.isBuildable() returns 'false' when the job is disabled, which does not depend on the Jenkins core change.

However, because Jenkins core and plugins use AbstractProject.isDisabled() rather than Job<?,?>.isDisabled() (introduced in https://github.com/jenkinsci/jenkins/pull/2544) there may be some odd interactions until other plugins are updated, since they won't be able to tell when pipeline jobs are disabled.
