### PR TITLE
Introduce copyLogsExecutorService to avoid blocking Timer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -51,7 +51,9 @@ import hudson.scm.ChangeLogSet;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.security.ACL;
+import hudson.util.DaemonThreadFactory;
 import hudson.util.Iterators;
+import hudson.util.NamingThreadFactory;
 import hudson.util.NullStream;
 import hudson.util.PersistedList;
 import java.io.File;
@@ -68,7 +70,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -227,6 +231,13 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         throw sleep();
     }
 
+    private static ScheduledExecutorService copyLogsExecutorService;
+    private static synchronized ScheduledExecutorService copyLogsExecutorService() {
+        if (copyLogsExecutorService == null) {
+            copyLogsExecutorService = new /*ErrorLogging*/ScheduledThreadPoolExecutor(5, new NamingThreadFactory(new DaemonThreadFactory(), "WorkflowRun.copyLogs"));
+        }
+        return copyLogsExecutorService;
+    }
     private AsynchronousExecution sleep() {
         final AsynchronousExecution asynchronousExecution = new AsynchronousExecution() {
             @Override public void interrupt(boolean forShutdown) {
@@ -257,7 +268,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             }
         };
         final AtomicReference<ScheduledFuture<?>> copyLogsTask = new AtomicReference<>();
-        copyLogsTask.set(Timer.get().scheduleAtFixedRate(new Runnable() {
+        copyLogsTask.set(copyLogsExecutorService().scheduleAtFixedRate(new Runnable() {
             @Override public void run() {
                 synchronized (completed) {
                     if (completed.get()) {
@@ -273,7 +284,14 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         listener = new StreamBuildListener(new NullStream());
                         return;
                     }
-                    copyLogs();
+                    Thread t = Thread.currentThread();
+                    String old = t.getName();
+                    t.setName(old + " (" + WorkflowRun.this + ")");
+                    try {
+                        copyLogs();
+                    } finally {
+                        t.setName(old);
+                    }
                 }
             }
         }, 1, 1, TimeUnit.SECONDS));


### PR DESCRIPTION
@cyrille-leclerc found a case where all ten `Timer` threads were blocked in `WorkflowRun.copyLogs`, either inside `LogActionImpl.getLogText` or `writeRawLogTo`. The cause is unknown—perhaps an NFS outage. At any rate, it is unwise to block `Timer` indefinitely, because that prevents other things in the system from progressing, notably `DurableTaskStep.Execution.check`. This patch ensures that log copying is segregated into its own thread pool, which could bog down but not break anything else.

(`check` imposes a timeout on itself. I thought of doing that here as well, but the I/O calls seem uninterruptible: `FileInputStream.close0` etc.)

@reviewbybees