### PR TITLE
[FIXED JENKINS-38454] Make sure we add the triggers before starting.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -445,6 +445,10 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         return triggerProp;
     }
 
+    public void addTriggersJobPropertyWithoutStart(PipelineTriggersJobProperty prop) throws IOException {
+        super.addProperty(prop);
+    }
+
     public void setTriggers(List<Trigger<?>> inputTriggers) throws IOException {
         triggers = null;
         BulkChange bc = new BulkChange(this);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -96,6 +96,7 @@ import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobP
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -445,6 +446,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         return triggerProp;
     }
 
+    @Restricted(NoExternalUse.class)
     public void addTriggersJobPropertyWithoutStart(PipelineTriggersJobProperty prop) throws IOException {
         super.addProperty(prop);
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -145,14 +145,17 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
             throw new Descriptor.FormException(e, null);
         }
 
-        this.stopTriggers();
+        try {
+            owner.removeProperty(this);
+            PipelineTriggersJobProperty thisProp = new PipelineTriggersJobProperty(new ArrayList<Trigger>(trigList.toList()));
 
-        PipelineTriggersJobProperty thisProp = new PipelineTriggersJobProperty(new ArrayList<Trigger>(trigList.toList()));
-        thisProp.setOwner(owner);
+            owner.addTriggersJobPropertyWithoutStart(thisProp);
 
-        thisProp.startTriggers(true);
-
-        return thisProp;
+            thisProp.startTriggers(true);
+            return thisProp;
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Extension(ordinal = -100)

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -49,9 +49,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @SuppressWarnings("rawtypes")
 public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
+    private static final Logger LOGGER = Logger.getLogger(PipelineTriggersJobProperty.class.getName());
+
     private List<Trigger<?>> triggers = new ArrayList<>();
 
     @DataBoundConstructor
@@ -133,7 +137,7 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
     @CheckForNull
     @Override
     public PipelineTriggersJobProperty reconfigure(@Nonnull StaplerRequest req, @CheckForNull JSONObject form) throws Descriptor.FormException {
-        DescribableList<Trigger<?>,TriggerDescriptor> trigList = new DescribableList<>(Saveable.NOOP);
+        DescribableList<Trigger<?>, TriggerDescriptor> trigList = new DescribableList<>(Saveable.NOOP);
         try {
             JSONObject triggerSection = new JSONObject();
             if (form != null) {
@@ -145,6 +149,8 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
             throw new Descriptor.FormException(e, null);
         }
 
+        PipelineTriggersJobProperty oldProp = owner.getTriggersJobProperty();
+
         try {
             owner.removeProperty(this);
             PipelineTriggersJobProperty thisProp = new PipelineTriggersJobProperty(new ArrayList<Trigger>(trigList.toList()));
@@ -154,8 +160,19 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
             thisProp.startTriggers(true);
             return thisProp;
         } catch (IOException e) {
-            return null;
+            LOGGER.log(Level.WARNING, "could not configure triggers", e);
         }
+
+        if (owner.getTriggersJobProperty() == null && oldProp != null) {
+            try {
+                owner.addTriggersJobPropertyWithoutStart(oldProp);
+                oldProp.startTriggers(true);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, "could not revert to original configured triggers", e);
+            }
+        }
+
+        return oldProp;
     }
 
     @Extension(ordinal = -100)

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/QueryingMockTrigger.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/QueryingMockTrigger.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *
+ */
+
+package org.jenkinsci.plugins.workflow.job.properties;
+
+import hudson.Extension;
+import hudson.model.BuildableItem;
+import hudson.model.Item;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import jenkins.model.ParameterizedJobMixIn;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryingMockTrigger extends Trigger<BuildableItem> {
+
+    /** elements are true or false for {@code start}, null for {@code stop} */
+    public static List<Boolean> startsAndStops = new ArrayList<>();
+
+    public transient boolean isStarted;
+
+    public transient boolean foundSelf = false;
+
+    @DataBoundConstructor
+    public QueryingMockTrigger() {}
+
+    @Override public void start(BuildableItem project, boolean newInstance) {
+        super.start(project, newInstance);
+        for (Trigger t : ((ParameterizedJobMixIn.ParameterizedJob)project).getTriggers().values()) {
+            if (t instanceof QueryingMockTrigger) {
+                foundSelf = true;
+            }
+        }
+
+        startsAndStops.add(newInstance);
+        isStarted = true;
+    }
+
+    @Override public void stop() {
+        super.stop();
+        startsAndStops.add(null);
+        isStarted = false;
+    }
+
+    public Boolean currentStatus() {
+        if (!startsAndStops.isEmpty()) {
+            return startsAndStops.get(startsAndStops.size() - 1);
+        } else {
+            return null;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends TriggerDescriptor {
+
+        @Override public boolean isApplicable(Item item) {
+            return true;
+        }
+
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPresentDuringStart.json
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest/triggerPresentDuringStart.json
@@ -1,0 +1,48 @@
+{
+  "name": "triggerPresent",
+  "description": "",
+  "_empty_": [
+    "",
+    "0"
+  ],
+  "properties": {
+    "stapler-class-bag": "true",
+    "jenkins-model-BuildDiscarderProperty": {
+      "specified": false,
+      "_empty_": "0",
+      "strategy": {
+        "daysToKeepStr": "",
+        "numToKeepStr": "",
+        "artifactDaysToKeepStr": "",
+        "artifactNumToKeepStr": "",
+        "stapler-class": "hudson.tasks.LogRotator",
+        "$class": "hudson.tasks.LogRotator"
+      }
+    },
+    "hudson-model-ParametersDefinitionProperty": {
+      "specified": false
+    },
+    "org-jenkinsci-plugins-workflow-job-properties-PipelineTriggersJobProperty": {
+      "triggers": {
+        "stapler-class-bag": "true",
+        "org-jenkinsci-plugins-workflow-job-properties-QueryingMockTrigger": {
+          
+        }
+      }
+    }
+  },
+  "hasCustomQuietPeriod": false,
+  "quiet_period": "0",
+  "displayNameOrNull": "",
+  "definition": {
+    "script": "",
+    "_empty_": [
+      "try sample Pipeline...",
+      "\u0001\u0001"
+    ],
+    "sandbox": true,
+    "stapler-class": "org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition",
+    "$class": "org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition"
+  },
+  "core:apply": ""
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-38454
abayer: 
```
This was...complex. But it works. We make sure the triggers property
has been added before starting, in case the start method for a trigger
class expects the trigger to already be present on the job. Existing
tests all pass, and the new test failed without the changes to
WorkflowJob and PipelineTriggersJobProperty. Phew.

Note - I'm working on getting rid of the need for posting hardcoded
JSON and just using form manipulation.
```

Creating PR to get artifact for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/workflow-job-plugin/28)
<!-- Reviewable:end -->
