### PR TITLE
[JENKINS-35098] Work around core misfeature when using 1.642.x or 1.651.x

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -51,6 +51,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.model.listeners.SCMListener;
 import hudson.scm.ChangeLogSet;
+import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.security.ACL;
@@ -674,7 +675,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (co.changelogFile != null && co.changelogFile.isFile()) {
                     try {
                         ChangeLogSet<? extends ChangeLogSet.Entry> changeLogSet =
-                                co.scm.createChangeLogParser().parse(this, co.scm.getEffectiveBrowser(), co.changelogFile);
+                                co.scm.createChangeLogParser().parse(this, getEffectiveBrowser(co.scm), co.changelogFile);
                         if (!changeLogSet.isEmptySet()) {
                             changeSets.add(changeLogSet);
                         }
@@ -685,6 +686,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             }
         }
         return changeSets;
+    }
+
+    /** Replacement for {@link SCM#getEffectiveBrowser} to work around JENKINS-35098. TODO 2.7.3+ delete */
+    private static RepositoryBrowser<?> getEffectiveBrowser(SCM scm) {
+        RepositoryBrowser<?> b = scm.getBrowser();
+        return b != null ? b : scm.guessBrowser();
     }
 
     @RequirePOST


### PR DESCRIPTION
Pending an update to a core with https://github.com/jenkinsci/jenkins/pull/2371 (or a backport), this should avoid a performance penalty observed from Stage View:

```
12345msec elapsed in Handling GET …/job/master/wfapi/runs …
    java.util.TreeMap.successor(TreeMap.java:2150)
    java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1208)
    java.util.TreeMap$KeyIterator.next(TreeMap.java:1261)
    nectar.plugins.rbac.groups.Group.isMatch(Group.java:472)
    nectar.plugins.rbac.groups.Group.isMatch(Group.java:425)
    nectar.plugins.rbac.groups.Group.isMatch(Group.java:362)
    nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:157)
    nectar.plugins.rbac.groups.GroupContainerACL._hasPermission(GroupContainerACL.java:106)
    nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:72)
    org.jenkinsci.plugins.workflow.multibranch.BranchJobProperty$1.hasPermission(BranchJobProperty.java:71)
    hudson.security.ACL.hasPermission(ACL.java:73)
    hudson.model.AbstractItem.hasPermission(AbstractItem.java:512)
    com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:581)
    hudson.model.Items.getAllItems(Items.java:357)
    hudson.model.Items.getAllItems(Items.java:377)
    hudson.model.Items.getAllItems(Items.java:377)
    hudson.model.Items.getAllItems(Items.java:353)
    jenkins.model.Jenkins.getAllItems(Jenkins.java:1444)
    hudson.scm.AutoBrowserHolder.infer(AutoBrowserHolder.java:77)
    hudson.scm.AutoBrowserHolder.get(AutoBrowserHolder.java:64)
    hudson.scm.SCM.getEffectiveBrowser(SCM.java:136)
    org.jenkinsci.plugins.workflow.job.WorkflowRun.getChangeSets(WorkflowRun.java:677)
    com.cloudbees.workflow.rest.external.ChangeSetExt.hasChanges(ChangeSetExt.java:149)
    com.cloudbees.workflow.rest.external.RunExt.createOld(RunExt.java:325)
    com.cloudbees.workflow.rest.external.RunExt.create(RunExt.java:304)
    com.cloudbees.workflow.rest.external.JobExt.create(JobExt.java:131)
    com.cloudbees.workflow.rest.endpoints.JobAPI.doRuns(JobAPI.java:72)
```

@reviewbybees esp. @svanoort
