### PR TITLE
Improve exception reporting from Job.logRotate

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -595,7 +595,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             save();
             getParent().logRotate();
         } catch (Exception x) {
-            LOGGER.log(Level.WARNING, null, x);
+            LOGGER.log(Level.WARNING, "failed to save " + this + " or perform log rotation", x);
         }
         onEndBuilding();
         if (completed != null) {


### PR DESCRIPTION
Seen sporadic exceptions in logs from a Windows-based master:

```
… WARNING o.j.p.workflow.job.WorkflowRun#finish: nulljava.io.IOException: …\123 is in use
    at hudson.model.Run.delete(Run.java:1500)
    at hudson.tasks.LogRotator.perform(LogRotator.java:144)
    at hudson.model.Job.logRotate(Job.java:478)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:541)
    at …
```

@reviewbybees
