### PR TITLE
[JENKINS-40255] Changed getSCMs(), now it checks for successful builds first.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -537,7 +537,10 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
     }
 
     @Override public Collection<? extends SCM> getSCMs() {
-        WorkflowRun b = getLastCompletedBuild();
+        WorkflowRun b = getLastSuccessfulBuild();
+        if (b == null) {
+            b = getLastCompletedBuild();
+        }
         if (b == null) {
             return Collections.emptySet();
         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.workflow.job;
+
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WorkflowJobTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+
+    @Issue("JENKINS-40255")
+    @Test public void getSCM() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+                    "  checkout(new hudson.scm.NullSCM())\n" +
+            "}"));
+        assertTrue("No runs has been performed and there should be no SCMs", p.getSCMs().isEmpty());
+
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+
+        assertEquals("Expecting one SCM",1, p.getSCMs().size());
+
+        p.setDefinition(new CpsFlowDefinition("error 'Fail!'"));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+
+        assertEquals("Last run should have failed", Result.FAILURE, p.getLastBuild().getResult());
+        assertEquals("Expecting one SCM even though last run failed",1, p.getSCMs().size());
+
+        p.setDefinition(new CpsFlowDefinition("echo 'Pass!'"));
+        p.scheduleBuild2(0);
+        j.waitUntilNoActivity();
+
+        assertEquals("Last run should have succeeded", Result.SUCCESS, p.getLastBuild().getResult());
+        assertEquals("Expecting zero SCMs",0, p.getSCMs().size());
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
@@ -23,23 +23,20 @@ public class WorkflowJobTest {
             "}"));
         assertTrue("No runs has been performed and there should be no SCMs", p.getSCMs().isEmpty());
 
-        p.scheduleBuild2(0);
-        j.waitUntilNoActivity();
+        j.buildAndAssertSuccess(p);
 
-        assertEquals("Expecting one SCM",1, p.getSCMs().size());
+        assertEquals("Expecting one SCM", 1, p.getSCMs().size());
 
         p.setDefinition(new CpsFlowDefinition("error 'Fail!'"));
-        p.scheduleBuild2(0);
-        j.waitUntilNoActivity();
 
-        assertEquals("Last run should have failed", Result.FAILURE, p.getLastBuild().getResult());
+        j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+
         assertEquals("Expecting one SCM even though last run failed",1, p.getSCMs().size());
 
         p.setDefinition(new CpsFlowDefinition("echo 'Pass!'"));
-        p.scheduleBuild2(0);
-        j.waitUntilNoActivity();
 
-        assertEquals("Last run should have succeeded", Result.SUCCESS, p.getLastBuild().getResult());
+        j.buildAndAssertSuccess(p);
+
         assertEquals("Expecting zero SCMs",0, p.getSCMs().size());
     }
 }


### PR DESCRIPTION
[JENKINS-40255](https://issues.jenkins-ci.org/browse/JENKINS-40255)

We use WorkflowJob.getSCMs() in order to get the SCM resources for each job so that we can do further analyse.  Unfortunately the implementation has been troublesome for us. If the run fails before the SCM step has finished or a failing run had succeeding SCM checkouts, then the wrong or none SCM information is returned.
This PR changes the behaviour so that it use a successful build if there is one, if not it falls back to the old behaviour (using last completed build).

This is my first PR to a Jenkins plugin, so I hope that I've done everything right :)