### PR TITLE
[JENKINS-41276] Make sure a FlowInterruptedException coming from a build abort is properly initialized with causes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>2.21</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -66,6 +66,11 @@
         <no-test-jar>false</no-test-jar>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.9-20170206.170109-1</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/20 -->
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -67,6 +67,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -86,6 +87,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
+import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import jenkins.model.lazy.BuildReference;
 import jenkins.model.lazy.LazyBuildMixIn;
@@ -270,7 +272,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         }
                         Executor executor = getExecutor();
                         try {
-                            execution.interrupt(executor.abortResult());
+                            Collection<CauseOfInterruption> causes = executor.getCausesOfInterruption();
+                            execution.interrupt(executor.abortResult(), causes.toArray(new CauseOfInterruption[causes.size()]));
                         } catch (Exception x) {
                             LOGGER.log(Level.WARNING, null, x);
                         }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -273,8 +273,7 @@ public class WorkflowRunTest {
         ex.interrupt();
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b2));
         iba = b2.getAction(InterruptedBuildAction.class);
-        assertNotNull(iba);
-        assertEquals(Collections.emptyList(), iba.getCauses());
+        assertNull(iba);
     }
 
     @Issue("JENKINS-41276")

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -47,6 +47,7 @@ import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -274,6 +275,29 @@ public class WorkflowRunTest {
         iba = b2.getAction(InterruptedBuildAction.class);
         assertNotNull(iba);
         assertEquals(Collections.emptyList(), iba.getCauses());
+    }
+
+    @Issue("JENKINS-41276")
+    @Test public void interruptCause() throws Exception {
+        r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        ScriptApproval.get().approveSignature("method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses"); // TODO should probably be @Whitelisted
+        ScriptApproval.get().approveSignature("method jenkins.model.CauseOfInterruption$UserInterruption getUser"); // ditto
+        p.setDefinition(new CpsFlowDefinition("@NonCPS def users(e) {e.causes*.user}; try {semaphore 'wait'} catch (e) {echo(/users=${users(e)}/); throw e}", true));
+        final WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/1", b1);
+        ACL.impersonate(User.get("dev").impersonate(), new Runnable() {
+            @Override public void run() {
+                b1.getExecutor().doStop();
+            }
+        });
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b1));
+        r.assertLogContains("users=[dev]", b1);
+        InterruptedBuildAction iba = b1.getAction(InterruptedBuildAction.class);
+        assertNotNull(iba);
+        assertEquals(Collections.singletonList(new CauseOfInterruption.UserInterruption("dev")), iba.getCauses());
+        String log = JenkinsRule.getLog(b1);
+        assertEquals(log, 1, StringUtils.countMatches(log, jenkins.model.Messages.CauseOfInterruption_ShortDescription("dev")));
     }
 
     @Test


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-step-api-plugin/pull/20.

@reviewbybees