### PR TITLE
Use Functions.printThrowable to provide more legible stack traces in 2.43+

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -29,6 +29,7 @@ import hudson.BulkChange;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Launcher;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -641,7 +642,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
             } catch (AbortException x) {
                 listener.error("polling failed in " + co.workspace + " on " + co.node + ": " + x.getMessage());
             } catch (Exception x) {
-                x.printStackTrace(listener.error("polling failed in " + co.workspace + " on " + co.node));
+                listener.error("polling failed in " + co.workspace + " on " + co.node).println(Functions.printThrowable(x).trim()); // TODO 2.43+ use Functions.printStackTrace
             }
         }
         return result;

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -36,6 +36,7 @@ import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.XmlFile;
 import hudson.console.AnnotatedLargeText;
 import hudson.console.LineTransformationOutputStream;
@@ -621,7 +622,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             } else if (t instanceof FlowInterruptedException) {
                 ((FlowInterruptedException) t).handle(this, listener);
             } else if (t != null) {
-                t.printStackTrace(listener.getLogger());
+                listener.getLogger().println(Functions.printThrowable(t).trim()); // TODO 2.43+ use Functions.printStackTrace
             }
             listener.finished(getResult());
             listener.closeQuietly();


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/1485.

@reviewbybees