### PR TITLE
Avoid adding a PipelineTriggersJobProperty unless some triggers were actually configured

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -196,6 +196,8 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements B
         } else {
             quietPeriod = null;
         }
+        getTriggersJobProperty().stopTriggers();
+        getTriggersJobProperty().startTriggers(Items.currentlyUpdatingByXml());
     }
 
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -182,6 +182,13 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
         public String getDisplayName() {
             return "Build triggers";
         }
+
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            PipelineTriggersJobProperty prop = (PipelineTriggersJobProperty) super.newInstance(req, formData);
+            return prop.triggers.isEmpty() ? null : prop;
+        }
+
     }
 
     @Extension

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -148,9 +148,11 @@ public class PipelineTriggersJobPropertyTest {
     public void configRoundTrip() throws Exception {
         WorkflowJob defaultCase = r.jenkins.createProject(WorkflowJob.class, "defaultCase");
         assertTrue(defaultCase.getTriggers().isEmpty());
+        assertNull(defaultCase.getProperty(PipelineTriggersJobProperty.class));
 
         WorkflowJob roundTripDefault = r.configRoundtrip(defaultCase);
         assertTrue(roundTripDefault.getTriggers().isEmpty());
+        assertNull(defaultCase.getProperty(PipelineTriggersJobProperty.class));
 
         WorkflowJob withTriggerCase = r.jenkins.createProject(WorkflowJob.class, "withTriggerCase");
         withTriggerCase.addTrigger(new MockTrigger());

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -173,22 +173,12 @@ public class PipelineTriggersJobPropertyTest {
         assertEquals("[null, false, null, true, null, false]", MockTrigger.startsAndStops.toString());
     }
 
+    @Issue("JENKINS-42446")
     @Test
     public void triggerPresentDuringStart() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "triggerPresent");
-        r.configRoundtrip(p);
         assertNull(getTriggerFromList(QueryingMockTrigger.class,
                 p.getTriggersJobProperty().getTriggers()));
-        configSubmit(p);
-
-        QueryingMockTrigger t = getTriggerFromList(QueryingMockTrigger.class,
-                p.getTriggersJobProperty().getTriggers());
-        assertNotNull(t);
-        assertTrue(t.isStarted);
-        assertTrue(t.foundSelf);
-    }
-
-    private void configSubmit(WorkflowJob p) throws Exception {
         JenkinsRule.WebClient wc = r.createWebClient();
         String newConfig = org.apache.commons.io.IOUtils.toString(
                 PipelineTriggersJobPropertyTest.class.getResourceAsStream(
@@ -200,18 +190,6 @@ public class PipelineTriggersJobPropertyTest {
         params.add(new NameValuePair("json", newConfig));
         request.setRequestParameters(params);
         wc.getPage(request);
-    }
-
-    @Issue("JENKINS-42446")
-    @Test
-    public void triggerPresentAndStartedDuringCreate() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "triggerPresent");
-        // configRoundTrip NOT called here since we want to mimic
-        // a job creation operation.
-        assertNull(getTriggerFromList(QueryingMockTrigger.class,
-                p.getTriggersJobProperty().getTriggers()));
-        configSubmit(p);
-
         QueryingMockTrigger t = getTriggerFromList(QueryingMockTrigger.class,
                 p.getTriggersJobProperty().getTriggers());
         assertNotNull(t);


### PR DESCRIPTION
Incorporates #41, without which `triggerPresentDuringStart` would fail, though I do not think that is mergeable as written.

The idea of this PR is to ensure that in **Pipeline Syntax** for `properties`, if you do not select any triggers you will see just

```groovy
properties([])
```

and not

```
properties([pipelineTriggers([])])
```

@reviewbybees esp. @abayer