### PR TITLE
[FIXED JENKINS-43396] Global NodePropertys should be in environment

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -393,8 +393,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     @Override public EnvVars getEnvironment(TaskListener listener) throws IOException, InterruptedException {
         EnvVars env = super.getEnvironment(listener);
 
-        for (NodeProperty nodeProperty: Jenkins.getInstance().getGlobalNodeProperties()) {
-            nodeProperty.buildEnvVars(env,listener);
+        Jenkins instance = Jenkins.getInstance();
+        if (instance != null) {
+            for (NodeProperty nodeProperty : instance.getGlobalNodeProperties()) {
+                nodeProperty.buildEnvVars(env, listener);
+            }
         }
 
         // TODO EnvironmentContributingAction does not support Job yet:

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -56,6 +56,7 @@ import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.security.ACL;
+import hudson.slaves.NodeProperty;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.Iterators;
 import hudson.util.NamingThreadFactory;
@@ -391,6 +392,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     @Override public EnvVars getEnvironment(TaskListener listener) throws IOException, InterruptedException {
         EnvVars env = super.getEnvironment(listener);
+
+        for (NodeProperty nodeProperty: Jenkins.getInstance().getGlobalNodeProperties()) {
+            nodeProperty.buildEnvVars(env,listener);
+        }
+
         // TODO EnvironmentContributingAction does not support Job yet:
         ParametersAction a = getAction(ParametersAction.class);
         if (a != null) {


### PR DESCRIPTION
[JENKINS-43396](https://issues.jenkins-ci.org/browse/JENKINS-43396)

They currently show up once you enter a node block, but not for things
outside node blocks. This fixes that by adding them to
WorkflowRun.getEnvironment(listener).

cc @reviewbybees 