### PR TITLE
Ensure WorkflowRun instances are collectible immediately after completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.21</version>
+        <version>2.25</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,6 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
+        <jenkins-test-harness.version>2.20</jenkins-test-harness.version>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.2</workflow-support-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
-        <jenkins-test-harness.version>2.20</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2.19</jenkins-test-harness.version>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.2</workflow-support-plugin.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -624,7 +624,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** Handles normal build completion (including errors) but also handles the case that the flow did not even start correctly, for example due to an error in {@link FlowExecution#start}. */
     private void finish(@Nonnull Result r, @CheckForNull Throwable t) {
         setResult(r);
-        LOGGER.log(Level.INFO, "{0} completed: {1}", new Object[] {this, getResult()});
+        LOGGER.log(Level.INFO, "{0} completed: {1}", new Object[] {toString(), getResult()});
         if (listener == null) {
             LOGGER.log(Level.WARNING, this + " failed to start", t);
         } else {


### PR DESCRIPTION
Perusing a heap dump, I noticed a number of `WorkflowRun` instances which did not exist on disk, and whose root references came from `WebAppMain$1.records`, i.e., `Jenkins.logRecords`, which keeps the last 256 messages logged at `INFO` or higher.

Besides being confusing, this wastes a bit of heap if there are not many other messages being logged and the builds would otherwise be either deleted, or released from `BuildReference.SoftHolder`.

`Run.execute` has the same issue, though an `AbstractBuild` probably has a smaller memory footprint, and this is what I was interested in. Could file a matching core PR if anyone cares.

@reviewbybees