### PR TITLE
[JENKINS-43055] Support FlowExecutionListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.14-20170519.135335-5</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow-support-plugin.version}</version>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -107,6 +107,7 @@ import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionListener;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
@@ -256,6 +257,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             execution = newExecution;
             newExecution.start();
             executionPromise.set(newExecution);
+            FlowExecutionListener.fireRunning(execution, false);
+
         } catch (Throwable x) {
             execution = null; // ensures isInProgress returns false
             finish(Result.FAILURE, x);
@@ -607,6 +610,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             executionPromise.set(execution);
             if (!execution.isComplete()) {
                 // we've been restarted while we were running. let's get the execution going again.
+                FlowExecutionListener.fireRunning(execution, true);
+
                 try {
                     OutputStream logger = new FileOutputStream(getLogFile(), true);
                     listener = new StreamBuildListener(logger, Charset.defaultCharset());
@@ -676,6 +681,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         } catch (IOException x) {
             LOGGER.log(Level.WARNING, "failed to clean up stashes from " + this, x);
         }
+        FlowExecutionListener.fireCompleted(getExecution());
     }
 
     @Override public void deleteArtifacts() throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -25,10 +25,16 @@
 package org.jenkinsci.plugins.workflow.job;
 
 import com.google.inject.Inject;
+import hudson.ExtensionList;
 import hudson.model.Executor;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionListener;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -45,6 +51,8 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+
+import java.util.List;
 
 public class WorkflowRunRestartTest {
 
@@ -175,4 +183,79 @@ public class WorkflowRunRestartTest {
         }
     }
 
+    @Issue("JENKINS-43055")
+    @Test
+    public void flowExecutionListener() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition("echo 'Running for listener'; sleep 0; semaphore 'wait'; sleep 0; error 'fail'", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("wait/1", b);
+                ExecListener listener = ExtensionList.lookup(FlowExecutionListener.class).get(ExecListener.class);
+                assertNotNull(listener);
+                assertEquals(1, listener.started);
+                assertEquals(0, listener.resumed);
+                assertEquals(0, listener.finished);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                WorkflowRun b = p.getLastBuild();
+                assertTrue(b.isBuilding());
+                SemaphoreStep.success("wait/1", null);
+
+                story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+                story.j.assertLogContains("Running for listener", b);
+
+                ExecListener listener = ExtensionList.lookup(FlowExecutionListener.class).get(ExecListener.class);
+                assertNotNull(listener);
+                assertEquals(1, listener.started);
+                assertEquals(1, listener.resumed);
+                assertEquals(1, listener.finished);
+            }
+        });
+
+    }
+
+    @TestExtension("flowExecutionListener")
+    public static class ExecListener extends FlowExecutionListener {
+        int started;
+        int finished;
+        int resumed;
+
+        @Override
+        public void onRunning(FlowExecution execution, boolean resumed) {
+            boolean listHasExec = false;
+            for (FlowExecution e : FlowExecutionList.get()) {
+                if (e.equals(execution)) {
+                    listHasExec = true;
+                }
+            }
+            assertTrue(listHasExec);
+            started++;
+            if (resumed) {
+                this.resumed++;
+            }
+        }
+
+        @Override
+        public void onCompleted(FlowExecution execution) {
+            finished++;
+            for (FlowExecution e : FlowExecutionList.get()) {
+                assertNotEquals(e, execution);
+            }
+
+            assertTrue(execution.isComplete());
+            assertNotNull(execution.getCauseOfFailure());
+            List<FlowNode> heads = execution.getCurrentHeads();
+            assertEquals(1, heads.size());
+            assertTrue(heads.get(0) instanceof FlowEndNode);
+            FlowEndNode node = (FlowEndNode)heads.get(0);
+            assertEquals(Result.FAILURE, node.getResult());
+        }
+    }
 }


### PR DESCRIPTION
[JENKINS-43055](https://issues.jenkins-ci.org/browse/JENKINS-43055)

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/36, replaces https://github.com/jenkinsci/workflow-cps-plugin/pull/127

Note that we're not testing to see if `GraphListener.onNewHead` gets fired before `FlowExecutionListener.onCompleted`, because `FlowExecutionListener.onCompleted` is fired via `WorkflowRun.finish`, which itself is fired by `WorkflowRun.GraphL.onNewHead`. So...circular. =)

cc @reviewbybees 