### PR TITLE
Remove unnecessary stops/starts of triggers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -192,8 +192,10 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
 
     @Override public void addProperty(JobProperty jobProp) throws IOException {
         super.addProperty(jobProp);
-        getTriggersJobProperty().stopTriggers();
-        getTriggersJobProperty().startTriggers(Items.currentlyUpdatingByXml());
+        if (jobProp instanceof PipelineTriggersJobProperty) {
+            getTriggersJobProperty().stopTriggers();
+            getTriggersJobProperty().startTriggers(Items.currentlyUpdatingByXml());
+        }
     }
 
     @Override public boolean isBuildable() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -140,7 +140,7 @@ public class PipelineTriggersJobPropertyTest {
         assertEquals(mockFromProp, mockFromJob);
 
         assertNotNull(((MockTrigger)mockFromProp).currentStatus());
-        assertEquals("[null, false, null, false, null, false]", MockTrigger.startsAndStops.toString());
+        assertEquals("[null, false, null, false]", MockTrigger.startsAndStops.toString());
     }
 
     @Test


### PR DESCRIPTION
In the case where you are using the **properties()** step with job properties other that the **PipelineTriggersJobProperty**, we do not want
stops and starts of a trigger every time we update a non-PipelineTriggersJobProperty.

This can pose a problem for a trigger that may have established a connection to an external system and it is forced to stop/start
frequently.