### PR TITLE
[JENKINS-45067] - Prevent NPE in PipelineTriggersJobProperty#startTriggers() when owner is not assigned

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -98,7 +98,21 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
         }
     }
 
+    /**
+     * Starts all triggers.
+     * This method requires the property instance to be added to the {@link WorkflowJob} instance.
+     * Otherwise the triggers will be just skipped.
+     * 
+     * @param newInstance {@code true} if it is a newly created instance.
+     */
     public void startTriggers(boolean newInstance) {
+        if (owner == null && LOGGER.isLoggable(Level.FINE)) {
+            // This is a normal behavior. Even if we miss the triggers,
+            // They will be started once WorkflowJob#addProperty() is called (standard method override).
+            LOGGER.log(Level.FINE, "Cannot start triggers. Owner of the JobProperty has not been assigned yet", 
+                    new IllegalStateException("JobProperty owner is null"));
+        }
+        
         for (Trigger trigger : triggers) {
             try {
                 trigger.start(owner, newInstance);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -106,11 +106,14 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
      * @param newInstance {@code true} if it is a newly created instance.
      */
     public void startTriggers(boolean newInstance) {
-        if (owner == null && LOGGER.isLoggable(Level.FINE)) {
-            // This is a normal behavior. Even if we miss the triggers,
-            // They will be started once WorkflowJob#addProperty() is called (standard method override).
-            LOGGER.log(Level.FINE, "Cannot start triggers. Owner of the JobProperty has not been assigned yet", 
-                    new IllegalStateException("JobProperty owner is null"));
+        if (owner == null) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                // This is a normal behavior. Even if we miss the triggers,
+                // They will be started once WorkflowJob#addProperty() is called (standard method override).
+                LOGGER.log(Level.FINE, "Cannot start triggers. Owner of the JobProperty has not been assigned yet", 
+                        new IllegalStateException("JobProperty owner is null"));
+            }
+            return;
         }
         
         for (Trigger trigger : triggers) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -110,7 +110,7 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
             if (LOGGER.isLoggable(Level.FINE)) {
                 // This is a normal behavior. Even if we miss the triggers,
                 // They will be started once WorkflowJob#addProperty() is called (standard method override).
-                LOGGER.log(Level.FINE, "Cannot start triggers. Owner of the JobProperty has not been assigned yet", 
+                LOGGER.log(Level.WARNING, "Cannot start triggers. Owner of the JobProperty has not been assigned yet", 
                         new IllegalStateException("JobProperty owner is null"));
             }
             return;

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -43,6 +43,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -50,6 +51,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.jvnet.hudson.test.Issue;
 
 public class PipelineTriggersJobPropertyTest {
     @ClassRule
@@ -192,6 +194,16 @@ public class PipelineTriggersJobPropertyTest {
         assertNotNull(t);
         assertTrue(t.isStarted);
         assertTrue(t.foundSelf);
+    }
+    
+    @Test
+    @Issue("JENKINS-45067")
+    public void triggerMethodsShouldNotThrowNPEWhenNotAssigned() {
+        MockTrigger t = new MockTrigger();
+        PipelineTriggersJobProperty prop = new PipelineTriggersJobProperty(Arrays.asList(t));
+        
+        prop.startTriggers(true);
+        prop.stopTriggers();
     }
 
     private <T extends Trigger> T getTriggerFromList(Class<T> clazz, List<Trigger<?>> triggers) {


### PR DESCRIPTION
When somebody creates a property in API and occasionally triggers the startTriggers() method, Trigger#start(owner, bool) gets invoked with null argument, which violates the contract and causes NPE. I think this NPE should be prevented, because such RunTime exception is not documented in the class Javadoc, and hence it may cause issues in the API user code.

https://issues.jenkins-ci.org/browse/JENKINS-45067

@reviewbybees @abayer @jglick 
