### PR TITLE
[JENKINS-44548] Extend robustness fix to any runtime exception from FlowExecution.onLoad

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -610,7 +610,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         if (execution != null) {
             try {
                 execution.onLoad(new Owner(this));
-            } catch (IOException x) {
+            } catch (Exception x) {
                 LOGGER.log(Level.WARNING, null, x);
                 execution = null; // probably too broken to use
             }


### PR DESCRIPTION
[JENKINS-44548](https://issues.jenkins-ci.org/browse/JENKINS-44548)

Second line of defense after https://github.com/jenkinsci/workflow-cps-plugin/pull/158: even if we did get an NPE, at least do not throw it out of `WorkflowRun.onLoad`.

@reviewbybees