### PR TITLE
2.11.x: Add copyCheckouts(WorkflowRun) method.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -736,6 +736,19 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return checkouts;
     }
 
+    /**
+     * Copy the {@link #checkouts} from another non-null {@link WorkflowRun} to this one. This is used to preserve SCM
+     * information for polling.
+     *
+     * @param run A non-null run
+     */
+    public void copyCheckouts(@Nonnull WorkflowRun run) {
+        if (checkouts == null) {
+            checkouts = new PersistedList<>(this);
+        }
+        checkouts.addAll(run.checkouts(null));
+    }
+
     @Exported
     public synchronized List<ChangeLogSet<? extends ChangeLogSet.Entry>> getChangeSets() {
         if (changeSets == null) {


### PR DESCRIPTION
This will be used to copy the checkouts list from one run to another,
to support certain use cases where we need to ensure that the
checkouts list is propagated even though actual checkouts aren't
happening.

cc @reviewbybees 