### PR TITLE
master: Add copyCheckouts(WorkflowRun) method.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -106,6 +106,7 @@ import org.jenkinsci.plugins.workflow.FilePathUtils;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.flow.FlowCopier;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
@@ -752,16 +753,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return checkouts;
     }
 
-    /**
-     * Copy the {@link #checkouts} from another non-null {@link WorkflowRun} to this one. This is used to preserve SCM
-     * information for polling.
-     *
-     * @param run A non-null run
-     */
-    public synchronized void copyCheckouts(@Nonnull WorkflowRun run) {
-        checkouts(null).addAll(run.checkouts(null));
-    }
-
     @Override
     @Exported
     public synchronized List<ChangeLogSet<? extends ChangeLogSet.Entry>> getChangeSets() {
@@ -1013,4 +1004,14 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         }
     }
 
+    @Restricted(DoNotUse.class) // impl
+    @Extension public static class Checkouts extends FlowCopier.ByRun {
+
+        @Override public void copy(Run<?, ?> original, Run<?, ?> copy, TaskListener listener) throws IOException, InterruptedException {
+            if (original instanceof WorkflowRun && copy instanceof WorkflowRun) {
+                ((WorkflowRun)copy).checkouts(null).addAll(((WorkflowRun)original).checkouts(null));
+            }
+        }
+
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -758,11 +758,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
      *
      * @param run A non-null run
      */
-    public void copyCheckouts(@Nonnull WorkflowRun run) {
-        if (checkouts == null) {
-            checkouts = new PersistedList<>(this);
-        }
-        checkouts.addAll(run.checkouts(null));
+    public synchronized void copyCheckouts(@Nonnull WorkflowRun run) {
+        checkouts(null).addAll(run.checkouts(null));
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -752,6 +752,19 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return checkouts;
     }
 
+    /**
+     * Copy the {@link #checkouts} from another non-null {@link WorkflowRun} to this one. This is used to preserve SCM
+     * information for polling.
+     *
+     * @param run A non-null run
+     */
+    public void copyCheckouts(@Nonnull WorkflowRun run) {
+        if (checkouts == null) {
+            checkouts = new PersistedList<>(this);
+        }
+        checkouts.addAll(run.checkouts(null));
+    }
+
     @Override
     @Exported
     public synchronized List<ChangeLogSet<? extends ChangeLogSet.Entry>> getChangeSets() {


### PR DESCRIPTION
This will be used to copy the checkouts list from one run to another,
to support certain use cases where we need to ensure that the
checkouts list is propagated even though actual checkouts aren't
happening.

cc @reviewbybees 