### PR TITLE
[FIXED JENKINS-45460] Allow adding triggers after migration.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -71,7 +71,7 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
     }
 
     public void setTriggers(List<Trigger<?>> triggers) {
-        this.triggers = triggers;
+        this.triggers.addAll(triggers);
     }
 
     public List<Trigger<?>> getTriggers() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -71,7 +71,7 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
     }
 
     public void setTriggers(List<Trigger<?>> triggers) {
-        this.triggers.addAll(triggers);
+        this.triggers = new ArrayList<>(triggers);
     }
 
     public List<Trigger<?>> getTriggers() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -147,6 +147,10 @@ public class PipelineTriggersJobPropertyTest {
 
         p.addTrigger(newTimerTrigger);
 
+        // Verify that we only have two triggers and that one of them is a MockTrigger.
+        assertEquals(2, p.getTriggers().size());
+        assertNotNull(p.getTriggers().get(mockFromJob.getDescriptor()));
+
         Trigger newTimerFromJob = p.getTriggers().get(newTimerTrigger.getDescriptor());
         assertEquals(newTimerTrigger.getSpec(), newTimerFromJob.getSpec());
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobPropertyTest.java
@@ -141,6 +141,14 @@ public class PipelineTriggersJobPropertyTest {
 
         assertNotNull(((MockTrigger)mockFromProp).currentStatus());
         assertEquals("[null, false, null, false, null, false]", MockTrigger.startsAndStops.toString());
+
+        // Verify that we can replace an existing trigger.
+        Trigger newTimerTrigger = new TimerTrigger("@hourly");
+
+        p.addTrigger(newTimerTrigger);
+
+        Trigger newTimerFromJob = p.getTriggers().get(newTimerTrigger.getDescriptor());
+        assertEquals(newTimerTrigger.getSpec(), newTimerFromJob.getSpec());
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-45460](https://issues.jenkins-ci.org/browse/JENKINS-45460)

Before this, if you had triggers configured before upgrading from a
version that didn't yet have PipelineTriggersJobProperty,
PipelineTriggersJobProperty.setTriggers(List) was called via
WorkflowJob.onLoad with the old DescribableList triggers.toList() -
which returns an UnmodifiableList. Oops.

cc @reviewbybees 