### PR TITLE
[JENKINS-37845] Return SCM of CpsScmFlowDefinition if there is no pri…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>2.29</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -71,6 +71,7 @@ import hudson.util.DescribableList;
 import hudson.widgets.HistoryWidget;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -90,6 +91,7 @@ import jenkins.triggers.SCMTriggerItem;
 import net.sf.json.JSONObject;
 import org.acegisecurity.Authentication;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
 import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty;
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
@@ -520,6 +522,9 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         WorkflowRun b = getLastSuccessfulBuild();
         if (b == null) {
             b = getLastCompletedBuild();
+        }
+        if (b == null && definition instanceof CpsScmFlowDefinition) {
+            return Arrays.asList( ((CpsScmFlowDefinition)definition).getScm() );
         }
         if (b == null) {
             return Collections.emptySet();

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
@@ -49,6 +49,13 @@ public class WorkflowJobTest {
         assertEquals("Expecting zero SCMs",0, p.getSCMs().size());
     }
 
+    @Issue("JENKINS-37845")
+    @Test public void defaultToScmFromDefinition() throws Exception {
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsScmFlowDefinition(new GitSCM("https://sample.com/repository"), "Jenkinsfile"));
+        assertEquals("Expecting one SCM", 1, p.getSCMs().size());
+    }
+
     @Issue("JENKINS-34716")
     @Test public void polling() throws Exception {
         sampleRepo.init();


### PR DESCRIPTION
This pull request significantly improves the situation for the issues
* https://issues.jenkins-ci.org/browse/JENKINS-35132
* https://issues.jenkins-ci.org/browse/JENKINS-37217
* https://issues.jenkins-ci.org/browse/JENKINS-37845
* https://issues.jenkins-ci.org/browse/JENKINS-45120

The issue is that a pipeline job which has not yet been built can not be triggered by a Github push trigger. Github push triggering is only available after at least one manual build.

The fix solves the issue for the typical use-case where the Jenkinsfile is contained in the same Github repository which hosts the source to be built. In that use-case, the pipeline job is properly triggered on a Github push, even if the pipeline job has *not* been triggered manually before.

The fix does not solve the issue completely for use-cases
* where multiple Github repositories are used, or
* where the Jenkinsfile and source code are located in different Github repositories.

In these use-cases, a yet unbuilt pipeline job is only triggered by a Github push to the repository containing the Jenkinsfile. Still, this is an improvement over the current situation. I don't see any straight-forward path to solve the issue in these use-cases completely.