### PR TITLE
[FIXED JENKINS-45043] Add WorkflowJob/changes.properties

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/changes.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/changes.properties
@@ -1,0 +1,29 @@
+#
+# The MIT License
+#
+# Copyright (c) 2017, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#
+#
+
+changes.title={0} Changes
+from.label=since #{0}
+to.label=up to #{0}


### PR DESCRIPTION
[JENKINS-45043](https://issues.jenkins-ci.org/browse/JENKINS-45043)

Gets rid of changes.title showing up in the page title for Pipeline jobs' changes.

cc @reviewbybees 