### PR TITLE
[JENKINS-46945] Run duration set before RunListener.fireCompleted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -657,6 +657,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** Handles normal build completion (including errors) but also handles the case that the flow did not even start correctly, for example due to an error in {@link FlowExecution#start}. */
     private void finish(@Nonnull Result r, @CheckForNull Throwable t) {
         setResult(r);
+        duration = Math.max(0, System.currentTimeMillis() - getStartTimeInMillis());
         LOGGER.log(Level.INFO, "{0} completed: {1}", new Object[] {toString(), getResult()});
         if (listener == null) {
             LOGGER.log(Level.WARNING, this + " failed to start", t);
@@ -673,7 +674,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             listener.closeQuietly();
         }
         logsToCopy = null;
-        duration = Math.max(0, System.currentTimeMillis() - getStartTimeInMillis());
         try {
             save();
         } catch (Exception x) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -117,7 +117,7 @@ public class WorkflowRunTest {
     }
 
     @Extension
-    public static class DurationRunListener extends RunListener<Run> {
+    public static final class DurationRunListener extends RunListener<Run> {
         static long duration = 0L;
         @Override
         public void onCompleted(Run run, @Nonnull TaskListener listener) {


### PR DESCRIPTION
Doing this will put the calculation of duration at the same location
where this is handled in core Jenkins' Run class:
https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Run.java#L1758

Details here: https://issues.jenkins-ci.org/browse/JENKINS-46945