### PR TITLE
[JENKINS-43834] Add deprecated ABORT permission

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -62,6 +62,7 @@ import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import hudson.search.SearchIndexBuilder;
 import hudson.security.ACL;
+import hudson.security.Permission;
 import hudson.slaves.WorkspaceList;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.Trigger;
@@ -361,6 +362,12 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         return hasPermission(CANCEL);
     }
 
+    /**
+     * @deprecated Just use {@link #CANCEL}.
+     */
+    @Deprecated
+    public static final Permission ABORT = CANCEL;
+    
     @Override public Collection<? extends SubTask> getSubTasks() {
         // TODO mostly copied from AbstractProject, except SubTaskContributor is not available:
         List<SubTask> subTasks = new ArrayList<>();


### PR DESCRIPTION
[JENKINS-43834](https://issues.jenkins-ci.org/browse/JENKINS-43834)

Going forward (with core 2.86 or 2.87 and later, that is, anything after https://github.com/jenkinsci/jenkins/pull/3101 is merged), `CANCEL` will be used
in HistoryWidget, but this bandaids things for Pipelines on earlier
core versions.

cc @reviewbybees 