### PR TITLE
Restore lower core version until core 2.76+ is more widespread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.76</jenkins.version>
+        <jenkins.version>2.62</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <workflow-support-plugin.version>2.16</workflow-support-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -44,6 +44,8 @@ import hudson.console.LineTransformationOutputStream;
 import hudson.console.ModelHyperlinkNote;
 import hudson.model.Executor;
 import hudson.model.Item;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -424,6 +424,13 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 nodeProperty.buildEnvVars(env, listener);
             }
         }
+        // TODO EnvironmentContributingAction does not support Job yet:
+        ParametersAction a = getAction(ParametersAction.class);
+        if (a != null) {
+            for (ParameterValue v : a) {
+                v.buildEnvironment(this, env);
+            }
+        }
 
         EnvVars.resolve(env);
         return env;


### PR DESCRIPTION
Reverts the key parts of https://github.com/jenkinsci/workflow-job-plugin/pull/67/ so that we don't limit all future workflow-job upgrades to core 2.76.x  -- this one is a fairly trivial cleanup PR so I feel comfortable reverting it and then re-applying down the road. 

Justification: 

* current stats.jenkins.io shows just 10% of reporting jenkins installs (16233 out of 161173) have core 2.76+, and only ~3000 are on core 2.89.1.  
* We can assume that the users on really old cores don't care about plugin updates, but the users that do accept updates are often ~1 LTS release behind

Without the revert, we'd have to maintain regular backports of all fixes/enhancements to an earlier core version unless we wanted to abandon users who are 1 LTS behind.  For a major fix/enhancement, that's justified but this was just a small code cleanup.