### PR TITLE
Clear out the logPrefixCache at end of build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -670,6 +670,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             listener.closeQuietly();
         }
         logsToCopy = null;
+        logPrefixCache = null;
         try {
             save();
         } catch (Exception x) {


### PR DESCRIPTION
Optimization noted when doing memory use profiling with Durability settings - we carry around this cache that we no longer need when the build is done. 

@reviewbybees 