### PR TITLE
[JENKINS-49170] NPE can be thrown on null triggers list

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/properties/PipelineTriggersJobProperty.java
@@ -70,6 +70,15 @@ public class PipelineTriggersJobProperty extends JobProperty<WorkflowJob> {
         }
     }
 
+    @SuppressWarnings("unused") // called by deserialization
+    protected Object readResolve() {
+        if (triggers == null) {
+            LOGGER.log(Level.WARNING, "triggers attribute was null, this shouldn't happen.");
+            this.triggers = new ArrayList<>();
+        }
+        return this;
+    }
+
     public void setTriggers(List<Trigger<?>> triggers) {
         this.triggers = new ArrayList<>(triggers);
     }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49170

Protect about possible null value for the triggers attribute.

This shouldn't be possible now with the current code, so I suppose
from reading the code and doing some archeology that it was not
100% protected before 3ad2875370d99b99686a2f0b6e88e97f7cfa4ec1 for
instance where I see some defensive checks were added.

Protecting against this seen in production:

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty.stopTriggers(PipelineTriggersJobProperty.java:96)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.removeProperty(WorkflowJob.java:580)
	at hudson.model.Job.removeProperty(Job.java:535)
	at org.jenkinsci.plugins.workflow.job.WorkflowJob.setTriggers(WorkflowJob.java:540)
```

@reviewbybees 