### PR TITLE
Fix tests broken by [JENKINS-47393] when the CommandLauncher was removed from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
             <version>1.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>command-launcher</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Found in testing for any net-new JEP-200 complaints in the tests. 