### PR TITLE
[JEP-206] Always use UTF-8 for the main Pipeline log file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-support-plugin.version>2.19-rc287.918f5958551d</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
+        <workflow-support-plugin.version>2.20</workflow-support-plugin.version>
         <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <git-plugin.version>3.2.0</git-plugin.version>
         <jenkins-test-harness.version>2.33</jenkins-test-harness.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.36</version>
+        <version>3.4</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -62,11 +62,11 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.62</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-support-plugin.version>2.17</workflow-support-plugin.version>
-        <scm-api-plugin.version>2.1.1</scm-api-plugin.version>
+        <workflow-support-plugin.version>2.19-20180209.204154-1</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/56 -->
+        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
         <git-plugin.version>3.2.0</git-plugin.version>
     </properties>
     <dependencies>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-job</artifactId>
-    <version>2.17</version>
+    <version>2.18-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Job</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Job+Plugin</url>
@@ -47,7 +47,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>workflow-job-2.17</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -71,7 +71,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -250,7 +249,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         try {
             onStartBuilding();
             OutputStream logger = new FileOutputStream(getLogFile());
-            listener = new StreamBuildListener(logger, Charset.defaultCharset());
+            charset = "UTF-8"; // cannot override getCharset, and various Run methods do not call it anyway
+            listener = new StreamBuildListener(logger, getCharset());
             listener.started(getCauses());
             Authentication auth = Jenkins.getAuthentication();
             if (!auth.equals(ACL.SYSTEM)) {
@@ -648,7 +648,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
                 try {
                     OutputStream logger = new FileOutputStream(getLogFile(), true);
-                    listener = new StreamBuildListener(logger, Charset.defaultCharset());
+                    listener = new StreamBuildListener(logger, getCharset());
                     listener.getLogger().println("Resuming build at " + new Date() + " after Jenkins restart");
                 } catch (IOException x) {
                     LOGGER.log(Level.WARNING, null, x);

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -465,4 +465,12 @@ public class WorkflowRunTest {
         }
     }
 
+    @Issue("JENKINS-31096")
+    @Test public void unicode() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        String message = "¡Čau → there!";
+        p.setDefinition(new CpsFlowDefinition("echo '" + message + "'", true));
+        r.assertLogContains(message, r.buildAndAssertSuccess(p));
+    }
+
 }


### PR DESCRIPTION
[JEP-206](https://github.com/jenkinsci/jep/blob/master/jep/206/README.adoc)

Subsumes #102. Downstream of https://github.com/jenkinsci/workflow-support-plugin/pull/56. A tiny piece pulled out of #27 as _one component of_ a solution to [JENKINS-31096](https://issues.jenkins-ci.org/browse/JENKINS-31096). Without https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/64, you will get mojibake, but possibly no worse than you already do. Compare the attempt to do something similar for freestyle in https://github.com/jenkinsci/jenkins/pull/3231.