### PR TITLE
[JENKINS-38383] Avoid Stackoverflow and full-flowgraph scan when trying to get branch names for log prefixes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -25,9 +25,8 @@
 package org.jenkinsci.plugins.workflow.job;
 
 import com.google.common.base.Optional;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -120,10 +119,10 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.console.WorkflowConsoleLogger;
-import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -504,7 +503,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     long old = entry.getValue();
                     OutputStream logger;
 
-                    String prefix = getLogPrefix(node);
+                    String prefix = getBranchName(node);
                     if (prefix != null) {
                         logger = new LogLinePrefixOutputFilter(listener.getLogger(), "[" + prefix + "] ");
                     } else {
@@ -559,33 +558,61 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @GuardedBy("completed")
-    private transient LoadingCache<FlowNode,Optional<String>> logPrefixCache;
-    private @CheckForNull String getLogPrefix(FlowNode node) {
-        // TODO could also use FlowScanningUtils.fetchEnclosingBlocks(node).filter(FlowScanningUtils.hasActionPredicate(ThreadNameAction.class)),
-        // but this would not let us cache intermediate results
+    private transient Cache<FlowNode,Optional<String>> branchNameCache;  // TODO Consider making this a top-level FlowNode API
+
+    private Cache<FlowNode, Optional<String>> getBranchNameCache() {
         synchronized (completed) {
-            if (logPrefixCache == null) {
-                logPrefixCache = CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<FlowNode,Optional<String>>() {
-                    @Override public @Nonnull Optional<String> load(FlowNode node) {
-                        if (node instanceof BlockEndNode) {
-                            return Optional.fromNullable(getLogPrefix(((BlockEndNode) node).getStartNode()));
-                        }
-                        ThreadNameAction threadNameAction = node.getAction(ThreadNameAction.class);
-                        if (threadNameAction != null) {
-                            return Optional.of(threadNameAction.getThreadName());
-                        }
-                        for (FlowNode parent : node.getParents()) {
-                            String prefix = getLogPrefix(parent);
-                            if (prefix != null) {
-                                return Optional.of(prefix);
-                            }
-                        }
-                        return Optional.absent();
-                    }
-                });
+            if (branchNameCache == null) {
+                branchNameCache = CacheBuilder.newBuilder().weakKeys().build();
             }
-            return logPrefixCache.getUnchecked(node).orNull();
+            return branchNameCache;
         }
+    }
+
+    private @CheckForNull String getBranchName(FlowNode node) {
+        Cache<FlowNode, Optional<String>> cache = getBranchNameCache();
+
+        Optional<String> output = cache.getIfPresent(node);
+        if (output != null) {
+            return output.orNull();
+        }
+
+        // We must explicitly check for the current node being the start/end of a parallel branch
+        if (node instanceof BlockEndNode) {
+            output = Optional.fromNullable(getBranchName(((BlockEndNode) node).getStartNode()));
+            cache.put(node, output);
+            return output.orNull();
+        } else if (node instanceof BlockStartNode) { // And of course this node might be the start of a parallel branch
+            ThreadNameAction threadNameAction = node.getPersistentAction(ThreadNameAction.class);
+            if (threadNameAction != null) {
+                String name = threadNameAction.getThreadName();
+                cache.put(node, Optional.of(name));
+                return name;
+            }
+        }
+
+        // Check parent which will USUALLY result in a cache hit, but improve performance and avoid a stack overflow by not doing recursion
+        List<FlowNode> parents = node.getParents();
+        if (!parents.isEmpty()) {
+            FlowNode parent = parents.get(0);
+            output = cache.getIfPresent(parent);
+            if (output != null) {
+                cache.put(node, output);
+                return output.orNull();
+            }
+        }
+
+        // Fall back to looking for an enclosing parallel branch... but using more efficient APIs and avoiding a stack overflows
+        output = Optional.absent();
+        for (BlockStartNode myNode : node.iterateEnclosingBlocks()) {
+            ThreadNameAction threadNameAction = myNode.getPersistentAction(ThreadNameAction.class);
+            if (threadNameAction != null) {
+                output = Optional.of(threadNameAction.getThreadName());
+                break;
+            }
+        }
+        cache.put(node, output);
+        return output.orNull();
     }
 
     private static final class LogLinePrefixOutputFilter extends LineTransformationOutputStream {
@@ -1016,7 +1043,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     private void logNodeMessage(FlowNode node) {
         WorkflowConsoleLogger wfLogger = new WorkflowConsoleLogger(listener);
-        String prefix = getLogPrefix(node);
+        String prefix = getBranchName(node);
         if (prefix != null) {
             wfLogger.log(String.format("[%s] %s", prefix, node.getDisplayFunctionName()));
         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -602,7 +602,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             }
         }
 
-        // Fall back to looking for an enclosing parallel branch... but using more efficient APIs and avoiding a stack overflows
+        // Fall back to looking for an enclosing parallel branch... but using more efficient APIs and avoiding stack overflows
         output = Optional.absent();
         for (BlockStartNode myNode : node.iterateEnclosingBlocks()) {
             ThreadNameAction threadNameAction = myNode.getPersistentAction(ThreadNameAction.class);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -724,6 +724,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             listener.closeQuietly();
         }
         logsToCopy = null;
+        branchNameCache = null;
         try {
             save();
         } catch (Exception x) {


### PR DESCRIPTION
Solves [JENKINS-38383](https://issues.jenkins-ci.org/browse/JENKINS-38383) which could trigger errors upon restart with a complex Pipeline. 

Renames the `getPrefixCache` & its cache to better reflect what they do (get the branch name for a `FlowNode`). 

Also subsumes https://github.com/jenkinsci/workflow-job-plugin/pull/84 in passing since it's trivial and would cause a merge conflict there anyway. 

Should incidentally fix [this issue noted in JENKINS-50350](https://issues.jenkins-ci.org/browse/JENKINS-50350?focusedCommentId=332985&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-332985).

I *think* this will also avoid some really grotesque failures seen by organizations as a result of quirks in `getLogPrefix` & the error handling in the previous `LoadingCache`.