### PR TITLE
Fix resume issues [JENKINS-49686] and [JENKINS-50199] and [JENKINS-50407]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <workflow-support-plugin.version>2.17</workflow-support-plugin.version>
         <scm-api-plugin.version>2.1.1</scm-api-plugin.version>
         <git-plugin.version>3.2.0</git-plugin.version>
+        <jenkins-test-harness.version>2.33</jenkins-test-harness.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1022,10 +1022,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             if (node instanceof FlowEndNode) {
                 finish(((FlowEndNode) node).getResult(), execution != null ? execution.getCauseOfFailure() : null);
             } else {
-                try {
-                    save();
-                } catch (IOException x) {
-                    LOGGER.log(Level.WARNING, null, x);
+                if (execution != null && execution.getDurabilityHint().isPersistWithEveryStep()) {
+                    try {
+                        save();
+                    } catch (IOException x) {
+                        LOGGER.log(Level.WARNING, null, x);
+                    }
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -656,7 +656,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 boolean completedStateNotPersisted = completed == null;
                 super.onLoad();
 
-                // TODO See if we can simply this, especially around interactions with 'completed'.
+                // TODO See if we can simplify this, especially around interactions with 'completed'.
 
                 if (execution != null && (completed == null || !completed.get())) {
                     FlowExecution fetchedExecution = getExecution();  // Triggers execution.onLoad so we can resume running if not done

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -218,6 +218,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** Used internally to ensure listener has been initialized correctly. */
     StreamBuildListener getListener() {
         // Un-synchronized to prevent deadlocks (combination of run and logCopyGuard) until the log-handling rewrite removes the log copying
+        // Note that in portions where multithreaded access is possible we are already synchronizing on logCopyGuard
         if (listener == null) {
             try {
                 OutputStream logger = new FileOutputStream(getLogFile(), true);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -152,8 +152,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         }
     }
 
-    /** null until started, or after serious failures or hard kill */
-    private @CheckForNull FlowExecution execution;
+    /** Null until started, or after serious failures or hard kill. */
+    @CheckForNull FlowExecution execution; // Not private for test use only
 
     /**
      * {@link Future} that yields {@link #execution}, when it is fully configured and ready to be exposed.
@@ -172,7 +172,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     private transient boolean allowKill;
 
     /** Controls whether or not our execution has been initialized via its {@link FlowExecution#onLoad(FlowExecutionOwner)} method yet if.*/
-    private transient boolean executionLoaded = false;
+    transient boolean executionLoaded = false;  // NonPrivate for tests
 
     /**
      * Cumulative list of people who contributed to the build problem.
@@ -190,11 +190,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /**
      * Flag for whether or not the build has completed somehow.
      * This was previously a transient field, so we may need to recompute in {@link #onLoad} based on {@link FlowExecution#isComplete}.
-     *
-     * TODO Finish off JENKINS-45585 bits by removing the need to null out {@link #execution} merely to force {@link #isInProgress} to be false
-     * in the case of broken or hard-killed builds which lack a single head node.
      */
-    private AtomicBoolean completed;
+    AtomicBoolean completed;  // Non-private for testing
 
     private transient Object logCopyGuard = new Object();
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -196,7 +196,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     private transient Object logCopyGuard = new Object();
 
     /** map from node IDs to log positions from which we should copy text */
-    Map<String,Long> logsToCopy;
+    Map<String,Long> logsToCopy;  // Exposed for testing
 
     /** JENKINS-26761: supposed to always be set but sometimes is not. Access only through {@link #checkouts(TaskListener)}. */
     private @CheckForNull List<SCMCheckout> checkouts;
@@ -213,7 +213,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return logCopyGuard;
     }
 
-    /** Avoids creating new instances, analogous to {@link TaskListener} but as full StreamBuildListener. */
+    /** Avoids creating new instances, analogous to {@link TaskListener#NULL} but as full StreamBuildListener. */
     static final StreamBuildListener NULL_LISTENER = new StreamBuildListener(new NullStream());
 
     /** Used internally to ensure listener has been initialized correctly. */

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -688,6 +688,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                             completed.set(true);
                         }
                     }
+                } else if (execution == null) {
+                    completed = new AtomicBoolean(true);
                 }
                 if (completedStateNotPersisted && completed.get()) {
                     try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -651,12 +651,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         fetchedExecution.addListener(new GraphL());
                         executionPromise.set(fetchedExecution);
 
-                        if (completed == null) {
-                            completed = new AtomicBoolean(fetchedExecution.isComplete());
-                        } else {
-                            completed.set(fetchedExecution.isComplete());
-                        }
-
+                        completed = new AtomicBoolean(fetchedExecution.isComplete());
                         if (!completed.get()) {
                             // we've been restarted while we were running. let's get the execution going again.
                             FlowExecutionListener.fireResumed(fetchedExecution);
@@ -675,8 +670,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                                     Queue.getInstance().schedule(new AfterRestartTask(WorkflowRun.this), 0);
                                 }
                             });
-                        } else { // Error when calling execution.onLoad
-                            // FIXME need a way to handle executionPromise, completed state, etc correctly!
                         }
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -304,7 +304,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             if (!loggedHintOverride) {  // Avoid double-logging
                 myListener.getLogger().println("Running in Durability level: "+DurabilityHintProvider.suggestedFor(this.project));
             }
-
+            save();  // Save before we add to the FlowExecutionList, to ensure we never have a run with a null build.
             synchronized (getLogCopyGuard()) {  // Technically safe but it makes FindBugs happy
                 FlowExecutionList.get().register(owner);
                 newExecution.addListener(new GraphL());
@@ -569,7 +569,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         }
         if (modified) {
             try {
-                if (this.execution != null && this.execution.getDurabilityHint().isPersistWithEveryStep()) {
+                if (this.execution == null || this.execution.getDurabilityHint().isPersistWithEveryStep()) {
                     save();
                 }
             } catch (IOException x) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -79,6 +79,7 @@ public class WorkflowRunRestartTest {
             SemaphoreStep.success("wait/1", null);
             r.assertBuildStatusSuccess(r.waitForCompletion(b));
             assertTrue(b.completed.get());
+            assertNull(b.logsToCopy);
         });
     }
 
@@ -103,6 +104,7 @@ public class WorkflowRunRestartTest {
             FlowExecution fe = b.getExecution();
             assertTrue(b.executionLoaded);
             assertNotNull(fe.getOwner());
+            assertNull(b.logsToCopy);
         });
     }
 
@@ -164,6 +166,7 @@ public class WorkflowRunRestartTest {
             WorkflowRun b = p.getBuildByNumber(1);
             assertFalse(b.isBuilding());
             assertFalse(b.executionLoaded);
+            assertNull(b.logsToCopy);
         });
     }
 
@@ -194,6 +197,8 @@ public class WorkflowRunRestartTest {
             r.waitForMessage("Hard kill!", b);
             r.waitForCompletion(b);
             r.assertBuildStatus(Result.ABORTED, b);
+            assertNull(b.logsToCopy);
+            assertTrue(b.completed.get());
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -88,6 +88,8 @@ public class WorkflowRunTest {
         assertFalse(b1.isBuilding());
         assertFalse(b1.isInProgress());
         assertFalse(b1.isLogUpdated());
+        assertTrue(b1.completed.get());
+        assertTrue(b1.executionLoaded);
         assertTrue(b1.getDuration() > 0);
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(b1, b2.getPreviousBuild());
@@ -259,6 +261,8 @@ public class WorkflowRunTest {
         WorkflowRun b = p.getLastBuild();
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
+        assertTrue(b.executionLoaded);
+        assertTrue(b.completed.get());
     }
 
     @Issue("JENKINS-29571")

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -88,7 +88,7 @@ public class WorkflowRunTest {
         assertFalse(b1.isBuilding());
         assertFalse(b1.isInProgress());
         assertFalse(b1.isLogUpdated());
-        assertTrue(b1.completed.get());
+        assertTrue(b1.completed);
         assertTrue(b1.executionLoaded);
         assertTrue(b1.getDuration() > 0);
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
@@ -262,7 +262,7 @@ public class WorkflowRunTest {
         assertNotNull(b);
         r.assertBuildStatusSuccess(r.waitForCompletion(b));
         assertTrue(b.executionLoaded);
-        assertTrue(b.completed.get());
+        assertTrue(b.completed);
     }
 
     @Issue("JENKINS-29571")


### PR DESCRIPTION
Aims to resolve (in conjunction with workflow-cps changes as well that help harden the logic): 

* [JENKINS-50199](https://issues.jenkins-ci.org/browse/JENKINS-50199)
* [JENKINS-49686](https://issues.jenkins-ci.org/browse/JENKINS-49686)
* [JENKINS-50407](https://issues.jenkins-ci.org/browse/JENKINS-50407)

Includes lazy-load for FlowExecutions (enhancement):  [JENKINS-45585](https://issues.jenkins-ci.org/browse/JENKINS-45585) -- which if merged will replace [49086](https://issues.jenkins-ci.org/browse/JENKINS-49086) because it will defer a ton of the load-time logic for completed Pipelines.

TODOs:

* Cross-test with workflow-cps durability tests
* Fix issue with unitialized listener field for unable-to-resume flows (may mandate changes in wf-cps too)
* Hardening: consider forcing atomic write of XML file when re-saving with the completed field persisted -- even when normally non-atomic (guarantees we won't mangle original build record if an error occurs upon save). 