### PR TITLE
Use 'agent' instead of 'slave'

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/Messages.properties
@@ -1,4 +1,4 @@
-WorkflowJob.Description=Orchestrates long-running activities that can span multiple build slaves. Suitable for \
+WorkflowJob.Description=Orchestrates long-running activities that can span multiple build agents. Suitable for \
   building pipelines (formerly known as workflows) and/or organizing complex activities that do not easily fit in \
   free-style job type.
 WorkflowJob.DisplayName=Pipeline


### PR DESCRIPTION
My understanding was that Jenkins was attempting to use the term 'agent' instead of 'slave' where possible. This change is in accord with that.