### PR TITLE
Protect against FlowExecutionOwner getting null execution due to lazy-load execution issues, also NPE-protect the executionPromise

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -110,7 +110,7 @@ public class WorkflowRunRestartTest {
         });
     }
 
-    @Issue("JENKINS-45585")  // Verifies execution lazy-load
+    @Issue({"JENKINS-45585", "JENKINS-50784"})  // Verifies execution lazy-load
     @Test public void lazyLoadExecution() {
         story.thenWithHardShutdown(r -> {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
@@ -130,15 +130,26 @@ public class WorkflowRunRestartTest {
         story.then(r -> {
             WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             WorkflowRun b = p.getBuildByNumber(1);
+            assertNotNull(b.asFlowExecutionOwner());
             assertNull(b.execution.getOwner());
             assertFalse(b.executionLoaded);
             assertTrue(b.completed);
             assertFalse(b.isBuilding());
+            assertNull(b.asFlowExecutionOwner().getOrNull());
 
             // Trigger lazy-load of execution
             FlowExecution fe = b.getExecution();
             assertNotNull(b.execution.getOwner());
             assertTrue(b.executionLoaded);
+            assertNotNull(b.asFlowExecutionOwner().getOrNull());
+            assertNotNull(b.asFlowExecutionOwner().get());
+        });
+        story.then( r-> {  // Verify that the FlowExecutionOwner can trigger lazy-load correctly
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            assertNotNull(b.asFlowExecutionOwner().get());
+            assertTrue(b.executionLoaded);
+            assertNotNull(b.asFlowExecutionOwner().getOrNull());
         });
     }
 


### PR DESCRIPTION
Part of [JENKINS-50784](https://issues.jenkins-ci.org/browse/JENKINS-50784).

While testing the ReplayAction I discovered we were hitting cases where the execution couldn't be loaded by via `FlowExecutionOwner.getOrNull()` **after** lazy load was triggered.  This is the solution, with a testcase.

Plus it ensures the programPromise is null-safe and, um, actually has values set for the promise.