### PR TITLE
Yet more fixes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -376,7 +376,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 });
             }
             @Override public boolean blocksRestart() {
-                return execution != null && execution.blocksRestart();
+                return execution != null && getExecution().blocksRestart();
             }
             @Override public boolean displayCell() {
                 return blocksRestart();
@@ -439,7 +439,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             return;
         }
         final Throwable x = new FlowInterruptedException(Result.ABORTED);
-        Futures.addCallback(execution.getCurrentExecutions(/* cf. JENKINS-26148 */true), new FutureCallback<List<StepExecution>>() {
+        Futures.addCallback(getExecution().getCurrentExecutions(/* cf. JENKINS-26148 */true), new FutureCallback<List<StepExecution>>() {
             @Override public void onSuccess(List<StepExecution> l) {
                 for (StepExecution e : Iterators.reverse(l)) {
                     StepContext context = e.getContext();
@@ -523,7 +523,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (execution == null) {
                     return; // broken somehow
                 }
-                node = execution.getNode(id);
+                node = getExecution().getNode(id);
             } catch (IOException x) {
                 LOGGER.log(Level.WARNING, null, x);
                 logsToCopy.remove(id);
@@ -803,7 +803,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         } catch (IOException x) {
             LOGGER.log(Level.WARNING, "failed to clean up stashes from " + this, x);
         }
-        FlowExecution exec = execution;
+        FlowExecution exec = getExecution();
         if (exec != null) {
             FlowExecutionListener.fireCompleted(exec);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -894,10 +894,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     @Override protected boolean isInProgress() {
         if (completed == Boolean.TRUE) {  // Has a persisted completion state
             return false;
+        } else {
+            // This may seem gratuitous but we MUST to check the execution in case 'completed' has not been set yet
+            // thus avoiding some (rare but possible) race conditions
+            FlowExecution exec = getExecution();
+            return exec != null && !exec.isComplete();
         }
-
-        // This may seem gratuitous but we MUST to check the execution in case 'completed' has not been set yet
-        return execution != null && !execution.isComplete() && (completed != Boolean.TRUE);  // Note: note completed can be null so can't just check for == false
     }
 
     @Override public boolean isLogUpdated() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1126,6 +1126,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         @Override public void onNewHead(FlowNode node) {
             synchronized (getLogCopyGuard()) {
                 copyLogs();
+                if (logsToCopy == null) {
+                    // Only happens when a FINISHED build loses FlowNodeStorage and we have to create placeholder nodes
+                    //  after the build is nominally completed.
+                    logsToCopy = new HashMap<String, Long>(3);
+                }
                 logsToCopy.put(node.getId(), 0L);
             }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -832,9 +832,17 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 executionLoaded = true;
                 return fetchedExecution;
             } catch (Exception x) {
+                if (result == null) {
+                    setResult(Result.FAILURE);
+                }
                 LOGGER.log(Level.WARNING, null, x);
                 execution = null; // probably too broken to use
                 executionLoaded = true;
+                try {
+                    save();  // Ensure we do not try to load again
+                } catch (IOException ioe) {
+                    LOGGER.log(Level.WARNING, "Error saving build to record irrecoverable FlowExecution");
+                }
                 return null;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -832,7 +832,10 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         blockableExecution.setResumeBlocked(parentBlocked);
                     }
                 }
-                fetchedExecution.addListener(new GraphL());
+                if (this.completed != Boolean.TRUE) {
+                    // Don't attach listeners for completed builds in case we do some work to create placeholder nodes
+                    fetchedExecution.addListener(new GraphL());
+                }
                 fetchedExecution.onLoad(new Owner(this));
                 SettableFuture<FlowExecution> settablePromise = getSettableExecutionPromise();
                 if (!settablePromise.isDone()) {
@@ -844,7 +847,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (result == null) {
                     setResult(Result.FAILURE);
                 }
-                LOGGER.log(Level.WARNING, null, x);
+                LOGGER.log(Level.WARNING, "Nulling out FlowExecution due to error in build "+this.getFullDisplayName(), x);
                 execution = null; // probably too broken to use
                 executionLoaded = true;
                 try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -710,9 +710,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     FlowExecution fetchedExecution = getExecution();  // Triggers execution.onLoad so we can resume running if not done
 
                     if (fetchedExecution != null) {
-                        fetchedExecution.addListener(new GraphL());
-                        getSettableExecutionPromise().set(fetchedExecution);
-
                         if (completed == null) {
                             completed = Boolean.valueOf(fetchedExecution.isComplete());
                         }
@@ -819,6 +816,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     /**
      * Gets the associated execution state, and do a more expensive loading operation if not initialized.
+     * Performs all the needed initialization for the execution pre-loading too -- sets the executionPromise, adds Listener, calls onLoad on it etc.
      * @return non-null after the flow has started, even after finished (but may be null temporarily when about to start, or if starting failed)
      */
     public synchronized @CheckForNull FlowExecution getExecution() {
@@ -834,6 +832,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         blockableExecution.setResumeBlocked(parentBlocked);
                     }
                 }
+                fetchedExecution.addListener(new GraphL());
                 fetchedExecution.onLoad(new Owner(this));
                 SettableFuture<FlowExecution> settablePromise = getSettableExecutionPromise();
                 if (!settablePromise.isDone()) {


### PR DESCRIPTION
MMMMM-multifix for (among others)

*  [JENKINS-50888](https://issues.jenkins-ci.org/browse/JENKINS-50888) - solved by fixing lazy-load issues where the execution's onLoad method isn't called. 
*  [JENKINS-50199](https://issues.jenkins-ci.org/browse/JENKINS-50199) - builds not showing as done and resuming
* Runs not showing as completed and hanging around as zombies if the FlowNodes can't load and they fail (because the GraphListener wasn't attached to call `finish`, the build was never marked completed). Also accounts for some with the 'blocksRestart' and similar.
* Lazy load changes removed protection against double onLoad calls, restoring that
* Fix various issues around lazy load and ensure build's result is set so it gets marked complete. 