### PR TITLE
Fix thread contention with WorkflowRun

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -450,7 +450,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         final Throwable x = new FlowInterruptedException(Result.ABORTED);
         FlowExecution exec = getExecution();
         if (exec == null) { // Already dead, just make sure statuses reflect that.
-            // FIXME do we need to synchronize on the WorkflowRun too?
             synchronized (getLogCopyGuard()) {
                 // Null execution means a hard-kill of the execution and build is by definition dead
                 // So we should make sure the result is set to failure if un-set and it's completed and then save.

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -443,6 +443,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         final Throwable x = new FlowInterruptedException(Result.ABORTED);
         FlowExecution exec = getExecution();
         if (exec == null) { // Already dead, just make sure statuses reflect that.
+            // FIXME do we need to synchronize on the WorkflowRun too?
             synchronized (getLogCopyGuard()) {
                 // Null execution means a hard-kill of the execution and build is by definition dead
                 // So we should make sure the result is set to failure if un-set and it's completed and then save.


### PR DESCRIPTION
Solves [JENKINS-51377](https://issues.jenkins-ci.org/browse/JENKINS-51377) mostly by ensuring the most common operations (things like getExecution) only block when they need to. 

Strategies:

- Leverage  [the Only Safe Form of double-checked locking](https://wiki.sei.cmu.edu/confluence/display/java/LCK10-J.+Use+a+correct+form+of+the+double-checked+locking+idiom) with `volatile` fields for some lazily-initialized `transient` fields rather than full synchronization - since we have almost exclusively *read* operations happening this greatly reduces thread contention.  The write operations there are protected by marking the fields volatile where simply nulling them or using synchronization for less trivial operations.

TODO:
* [X] Fix failures in the durability-fuzzing tests - AFAICT they're not regressions, just pre-existing.
* [x] Check if we need to synchronize on the `WorkflowRun` in the `#doTerm()` method
* [x] Check if we need to synchronize on the logCopyGuard in the `#save()` method to prevent mutation there (since we no longer synchronize on the getter for that guard object) -- solved by restoring synchronization on the getter.
* [x] Document order of locking for WorkflowRun vs logCopyGuard and verify order is enforced