### PR TITLE
WorkflowRun: Allow retrieval of logCopyGuard without lock.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -69,6 +69,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
@@ -197,6 +198,15 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     private transient Object logCopyGuard = new Object();
 
+    /**
+     * When deserializing, ensure that {@link #logCopyGuard} is initialized.
+     */
+    private void readObject(ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        logCopyGuard = new Object();
+    }
+
     /** map from node IDs to log positions from which we should copy text */
     Map<String,Long> logsToCopy;  // Exposed for testing
 
@@ -208,10 +218,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** True when first started, false when running after a restart. */
     private transient boolean firstTime;
 
-    private synchronized Object getLogCopyGuard() {
-        if (logCopyGuard == null) {
-            logCopyGuard = new Object();
-        }
+    private Object getLogCopyGuard() {
         return logCopyGuard;
     }
 


### PR DESCRIPTION
`WorkflowRun::logCopyGuard` is a private transient object that's used
to ensure mutual exclusion of certain operations. Unfortunately, the
getter for it (which initializes the field if it is `null`, as it
would be after deserialization) was `synchronized`, and thus could not
run at the same time as other potentially expensive synchronized
methods (like `getExecution`, which loads a `build.xml`, or `save`,
which writes one).

To work around, we implement a `readObject` method that will
explicitly initialize the `logCopyGuard` object. Now, the
`getLogCopyGuard` method can assume it is non-`null`, and therefore
does not need to be `synchronized`.

------------

Our Jenkins installation is affected by [JENKINS-19022](https://issues.jenkins-ci.org/browse/JENKINS-19022), with very large `build.xml` files that take tens of seconds to (de)serialize. Because of this, we were observing threads blocked for very long periods while trying to call `getLogCopyGuard`, only to then use its result for the finer-grained lock that they actually wanted.

I believe adding `readObject` like this preserves compatibility with existing serialized data, whereas the simpler approach of making `logCopyGuard` non-`transient` (and of a serializable type) does not. As it's a performance fix for a concurrency problem, I'm not sure I can write a useful unit test.