### PR TITLE
More threading improvements

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -911,7 +911,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** Initializes and returns the executionPromise to avoid null risk */
     @Nonnull
     private SettableFuture<FlowExecution> getSettableExecutionPromise() {
-        if (executionPromise != null) {
+        if (executionPromise != null) { // Double-checked locking safe rendered safe by volatile field
             return executionPromise;
         } else {
             synchronized(this) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -911,16 +911,18 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** Initializes and returns the executionPromise to avoid null risk */
     @Nonnull
     private SettableFuture<FlowExecution> getSettableExecutionPromise() {
-        if (executionPromise != null) { // Double-checked locking safe rendered safe by volatile field
-            return executionPromise;
-        } else {
+        SettableFuture execOut = executionPromise;
+        if (execOut == null) { // Double-checked locking safe rendered safe by volatile field
             synchronized(this) {
-                if (executionPromise == null) {
-                    executionPromise = SettableFuture.create();
+                execOut = executionPromise; // Fetch again from field in case another thread created it
+                if (execOut == null) {
+                    execOut = SettableFuture.create();
+                    executionPromise = execOut;
                 }
-                return executionPromise;
+                return execOut;
             }
         }
+        return execOut;
     }
 
     @Override public FlowExecutionOwner asFlowExecutionOwner() {


### PR DESCRIPTION
Fix excessive thread contention tied to:

> "Handling GET /job/jobname/wfapi/runs from $someIP : RequestHandlerThread[#4248]" id=421007 (0x66c8f) state=BLOCKED cpu=91%
    - waiting to lock <0x672df466> (a org.jenkinsci.plugins.workflow.job.WorkflowRun)
      owned by "Running CpsFlowExecution[Owner[jobnamething/21087:jobname #21087]]" id=420802 (0x66bc2)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.getSettableExecutionPromise(WorkflowRun.java:913)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecutionPromise(WorkflowRun.java:907)
    at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.getOrNull(WorkflowRun.java:1124)
    at org.jenkinsci.plugins.workflow.cps.RunningFlowActions.createFor(RunningFlowActions.java:51)
    at org.jenkinsci.plugins.workflow.cps.RunningFlowActions.createFor(RunningFlowActions.java:42)
    at hudson.model.Actionable.createFor(Actionable.java:114)
    at hudson.model.Actionable.getAction(Actionable.java:337)
    at com.cloudbees.workflow.rest.external.RunExt.isPendingInput(RunExt.java:345)
    at com.cloudbees.workflow.rest.external.RunExt.initStatus(RunExt.java:377)
    at com.cloudbees.workflow.rest.external.RunExt.createMinimal(RunExt.java:241)
    at com.cloudbees.workflow.rest.external.RunExt.createNew(RunExt.java:317)
    at com.cloudbees.workflow.rest.external.RunExt.create(RunExt.java:309)
    at com.cloudbees.workflow.rest.external.JobExt.create(JobExt.java:131)
    at com.cloudbees.workflow.rest.endpoints.JobAPI.doRuns(JobAPI.java:69)
