### PR TITLE
[JENKINS-51869] Example of update to drop --first-parent

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-4</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.19-20180719.153600-1</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/119 -->
+        <version>3.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.14</version>
+        <version>3.19-20180719.153600-1</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/119 -->
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/plugin-pom/pull/119. Note that this has deployed `https://2.24-rc760.d0b56943b4cf` as opposed to `master`’s `2.24-rc353.b6a4049f4755`.