### PR TITLE
[JENKINS-50199] Fix cases where builds would "resume" even though the execution is complete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.25</version>
+            <version>2.27</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -92,19 +92,19 @@
             <!-- Satisfy upper bound dependencies -->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.39</version>
+            <version>1.42</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.43</version>
+            <version>2.54</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>1.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,6 +130,12 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
             <version>2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-input-step</artifactId>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -877,7 +877,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                         if (fetchedExecution.isComplete()) {  // See JENKINS-50199 for cases where the execution is marked complete but build is not
                             // Somehow arrived at one of those weird states
                             this.completed = true;
-                            setResult(Result.FAILURE);
+                            Result finalResult = Result.FAILURE;
+                            List<FlowNode> heads = fetchedExecution.getCurrentHeads();
+                            if (!heads.isEmpty() && heads.get(0) instanceof FlowEndNode) {
+                                finalResult = ((FlowEndNode)(heads.get(0))).getResult();
+                            }
+                            setResult(finalResult);
                             fetchedExecution.removeListener(finishListener);
                             saveWithoutFailing();
                         } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -876,6 +876,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     if (this.completed != Boolean.TRUE) {
                         if (fetchedExecution.isComplete()) {  // See JENKINS-50199 for cases where the execution is marked complete but build is not
                             // Somehow arrived at one of those weird states
+                            LOGGER.log(Level.WARNING, "Found incomplete build with completed execution - display name: "+this.getFullDisplayName());
                             this.completed = true;
                             Result finalResult = Result.FAILURE;
                             List<FlowNode> heads = fetchedExecution.getCurrentHeads();

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -874,10 +874,18 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     }
                     fetchedExecution.onLoad(new Owner(this));
                     if (this.completed != Boolean.TRUE) {
-                        // Defer the normal listener to ensure onLoad can complete before finish() is called since that may
-                        // need the build to be loaded and can result in loading loops otherwise.
-                        fetchedExecution.removeListener(finishListener);
-                        fetchedExecution.addListener(new GraphL());
+                        if (fetchedExecution.isComplete()) {  // See JENKINS-50199 for cases where the execution is marked complete but build is not
+                            // Somehow arrived at one of those weird states
+                            this.completed = true;
+                            setResult(Result.FAILURE);
+                            fetchedExecution.removeListener(finishListener);
+                            saveWithoutFailing();
+                        } else {
+                            // Defer the normal listener to ensure onLoad can complete before finish() is called since that may
+                            // need the build to be loaded and can result in loading loops otherwise.
+                            fetchedExecution.removeListener(finishListener);
+                            fetchedExecution.addListener(new GraphL());
+                        }
                     }
                     SettableFuture<FlowExecution> settablePromise = getSettableExecutionPromise();
                     if (!settablePromise.isDone()) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
@@ -18,7 +18,6 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -296,7 +295,6 @@ public class CpsPersistenceTest {
     }
 
     @Test
-    @Ignore
     public void inProgressMaxPerfDirtyShutdown() throws Exception {
         final int[] build = new int[1];
         final String[] finalNodeId = new String[1];
@@ -401,11 +399,13 @@ public class CpsPersistenceTest {
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
             assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
         });
         story.then( j->{ // Once more, just to be sure it sticks
             WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
             WorkflowRun run = r.getBuildByNumber(build[0]);
             assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
         });
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
@@ -1,0 +1,432 @@
+package org.jenkinsci.plugins.workflow.job;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Run;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowDurabilityHint;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionList;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
+import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
+import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Stack;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests a series of failure cases where WorkflowJob interacts with the Cps persistence model in workflow-cps plugin.
+ * This verifies that the WorkflowJob end of the persistence world is handling basic cases correctly.
+ */
+public class CpsPersistenceTest {
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    /** Execution bombed out due to some sort of irrecoverable persistence issue. */
+    static void assertNulledExecution(WorkflowRun run) throws Exception {
+        if (run.isBuilding()) {
+            System.out.println("Run initially building, going to wait a second to see if it finishes, run="+run);
+            Thread.sleep(1000);
+        }
+        Assert.assertFalse(run.isBuilding());
+        Assert.assertNotNull(run.getResult());
+        FlowExecution fe = run.getExecution();
+        Assert.assertNull(fe);
+    }
+
+    private static void setCpsDoneFlag(CpsFlowExecution exec, boolean doneState) throws Exception {
+        Field doneField = exec.getClass().getDeclaredField("done");
+        doneField.setAccessible(true);
+        doneField.setBoolean(exec, doneState);
+    }
+
+    private static boolean getCpsDoneFlag(CpsFlowExecution exec) throws Exception {
+        Field doneField = exec.getClass().getDeclaredField("done");
+        doneField.setAccessible(true);
+        return doneField.getBoolean(exec);
+    }
+
+    private static Stack<BlockStartNode> getCpsBlockStartNodes(CpsFlowExecution exec) throws Exception {
+        Field startField = exec.getClass().getDeclaredField("startNodes");
+        startField.setAccessible(true);
+        Object ob = startField.get(exec);
+        if (ob instanceof Stack) {
+            return (Stack<BlockStartNode>)ob;
+        }
+        return null;
+    }
+
+    /** Verifies all the assumptions about a cleanly finished build. */
+    static void assertCompletedCleanly(WorkflowRun run) throws Exception {
+        if (run.isBuilding()) {
+            System.out.println("Run initially building, going to wait a second to see if it finishes, run="+run);
+            Thread.sleep(1000);
+        }
+        Assert.assertFalse(run.isBuilding());
+        Assert.assertNotNull(run.getResult());
+        FlowExecution fe = run.getExecution();
+        FlowExecutionList.get().forEach(f -> {
+            if (fe != null && f == fe) {
+                Assert.fail("FlowExecution still in FlowExecutionList!");
+            }
+        });
+        Assert.assertTrue("Queue not empty after completion!", Queue.getInstance().isEmpty());
+
+        if (fe instanceof CpsFlowExecution) {
+            CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
+            Assert.assertTrue(cpsExec.isComplete());
+            Assert.assertEquals(Boolean.TRUE, getCpsDoneFlag(cpsExec));
+            Assert.assertEquals(1, cpsExec.getCurrentHeads().size());
+            Assert.assertTrue(cpsExec.isComplete());
+            Assert.assertTrue(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
+            Stack<BlockStartNode> starts = getCpsBlockStartNodes(cpsExec);
+            Assert.assertTrue(starts == null || starts.isEmpty());
+            Assert.assertFalse(cpsExec.blocksRestart());
+        } else {
+            System.out.println("WARNING: no FlowExecutionForBuild");
+        }
+    }
+
+
+
+    static void assertCleanInProgress(WorkflowRun run) throws Exception {
+        Assert.assertTrue(run.isBuilding());
+        Assert.assertNull(run.getResult());
+        FlowExecution fe = run.getExecution();
+        AtomicBoolean hasExecutionInList = new AtomicBoolean(false);
+        FlowExecutionList.get().forEach(f -> {
+            if (fe != null && f == fe) {
+                hasExecutionInList.set(true);
+            }
+        });
+        if (!hasExecutionInList.get()) {
+            Assert.fail("Build completed but should still show in FlowExecutionList");
+        }
+        CpsFlowExecution cpsExec = (CpsFlowExecution)fe;
+        Assert.assertFalse(cpsExec.isComplete());
+        Assert.assertEquals(Boolean.FALSE, getCpsDoneFlag(cpsExec));
+        Assert.assertFalse(cpsExec.getCurrentHeads().get(0) instanceof FlowEndNode);
+        Stack<BlockStartNode> starts = getCpsBlockStartNodes(cpsExec);
+        Assert.assertTrue(starts != null && !starts.isEmpty());
+    }
+
+    static void assertResultMatchExecutionAndRun(WorkflowRun run, Result[] executionAndBuildResult) throws Exception {
+        Assert.assertEquals(executionAndBuildResult[0], ((CpsFlowExecution)(run.getExecution())).getResult());
+        Assert.assertEquals(executionAndBuildResult[1], run.getResult());
+    }
+
+    /** Create and run a basic build before we mangle its persisted contents.  Stores job number to jobIdNumber index 0. */
+    private static WorkflowRun runBasicBuild(JenkinsRule j, String jobName, int[] jobIdNumber, FlowDurabilityHint hint) throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, jobName);
+        job.setDefinition(new CpsFlowDefinition("echo 'doSomething'", true));
+        job.addProperty(new DurabilityHintJobProperty(hint));
+        WorkflowRun run = j.buildAndAssertSuccess(job);
+        jobIdNumber[0] = run.getNumber();
+        assertCompletedCleanly(run);
+        return run;
+    }
+
+    /** Create and run a basic build before we mangle its persisted contents.  Stores job number to jobIdNumber index 0. */
+    private static WorkflowRun runBasicBuild(JenkinsRule j, String jobName, int[] jobIdNumber) throws Exception {
+        return runBasicBuild(j, jobName, jobIdNumber, FlowDurabilityHint.MAX_SURVIVABILITY);
+    }
+
+    /** Sets up a running build that is waiting on input. */
+    private static WorkflowRun runBasicPauseOnInput(JenkinsRule j, String jobName, int[] jobIdNumber, FlowDurabilityHint durabilityHint) throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, jobName);
+        job.setDefinition(new CpsFlowDefinition("input 'pause'", true));
+        job.addProperty(new DurabilityHintJobProperty(durabilityHint));
+
+        WorkflowRun run = job.scheduleBuild2(0).getStartCondition().get();
+        ListenableFuture<FlowExecution> listener = run.getExecutionPromise();
+        FlowExecution exec = listener.get();
+        while(exec.getCurrentHeads().isEmpty() || (exec.getCurrentHeads().get(0) instanceof FlowStartNode)) {  // Wait until input step starts
+            System.out.println("Waiting for input step to begin");
+            Thread.sleep(50);
+        }
+        while(run.getAction(InputAction.class) == null) {  // Wait until input step starts
+            System.out.println("Waiting for input action to get attached to run");
+            Thread.sleep(50);
+        }
+        Thread.sleep(100L);  // A little extra buffer for persistence etc
+        jobIdNumber[0] = run.getNumber();
+        return run;
+    }
+
+    private static WorkflowRun runBasicPauseOnInput(JenkinsRule j, String jobName, int[] jobIdNumber) throws Exception {
+        return runBasicPauseOnInput(j, jobName, jobIdNumber, FlowDurabilityHint.MAX_SURVIVABILITY);
+    }
+
+    private static InputStepExecution getInputStepExecution(WorkflowRun run, String inputMessage) throws Exception {
+        InputAction ia = run.getAction(InputAction.class);
+        List<InputStepExecution> execList = ia.getExecutions();
+        return execList.stream().filter(e -> inputMessage.equals(e.getInput().getMessage())).findFirst().orElse(null);
+    }
+
+    final  static String DEFAULT_JOBNAME = "testJob";
+
+    /** Simulates something happening badly during final shutdown, which may cause build to not appear done. */
+    @Test
+    public void completedFinalFlowNodeNotPersisted() throws Exception {
+        final int[] build = new int[1];
+        final Result[] executionAndBuildResult = new Result[2];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+            String finalId = run.getExecution().getCurrentHeads().get(0).getId();
+
+            // Hack but deletes the file from disk
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            File f = new File(cpsExec.getStorageDir(), finalId+".xml");
+            f.delete();
+            executionAndBuildResult[0] = ((CpsFlowExecution)(run.getExecution())).getResult();
+            executionAndBuildResult[1] = run.getResult();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            //            assertNulledExecution(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+            assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+        });
+    }
+    /** Perhaps there was a serialization error breaking the FlowGraph persistence for non-durable mode. */
+    @Test
+    public void completedNoNodesPersisted() throws Exception {
+        final int[] build = new int[1];
+        final Result[] executionAndBuildResult = new Result[2];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+            FileUtils.deleteDirectory(((CpsFlowExecution)(run.getExecution())).getStorageDir());
+            executionAndBuildResult[0] = ((CpsFlowExecution)(run.getExecution())).getResult();
+            executionAndBuildResult[1] = run.getResult();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            // assertNulledExecution(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+            assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+        });
+    }
+
+    /** Simulates case where done flag was not persisted. */
+    @Test
+    public void completedButWrongDoneStatus() throws Exception {
+        final int[] build = new int[1];
+        final Result[] executionAndBuildResult = new Result[2];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicBuild(j, DEFAULT_JOBNAME, build);
+            String finalId = run.getExecution().getCurrentHeads().get(0).getId();
+
+            // Hack but deletes the FlowNodeStorage from disk
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            setCpsDoneFlag(cpsExec, false);
+            run.save();
+            executionAndBuildResult[0] = ((CpsFlowExecution)(run.getExecution())).getResult();
+            executionAndBuildResult[1] = run.getResult();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+            assertResultMatchExecutionAndRun(run, executionAndBuildResult);
+        });
+    }
+
+    @Test
+    public void inProgressNormal() throws Exception {
+        final int[] build = new int[1];
+        story.then( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCleanInProgress(run);
+            InputStepExecution exec = getInputStepExecution(run, "pause");
+            exec.doProceedEmpty();
+            j.waitForCompletion(run);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+
+    @Test
+    public void inProgressMaxPerfCleanShutdown() throws Exception {
+        final int[] build = new int[1];
+        story.then( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build, FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
+            // SHOULD still save at end via persist-at-shutdown hooks
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCleanInProgress(run);
+            InputStepExecution exec = getInputStepExecution(run, "pause");
+            exec.doProceedEmpty();
+            j.waitForCompletion(run);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.SUCCESS, run.getResult());
+        });
+    }
+
+    @Test
+    @Ignore
+    public void inProgressMaxPerfDirtyShutdown() throws Exception {
+        final int[] build = new int[1];
+        final String[] finalNodeId = new String[1];
+        story.thenWithHardShutdown( j -> {
+            runBasicPauseOnInput(j, DEFAULT_JOBNAME, build, FlowDurabilityHint.PERFORMANCE_OPTIMIZED);
+            // SHOULD still save at end via persist-at-shutdown hooks
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            Thread.sleep(1000);
+            j.waitForCompletion(run);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(Result.FAILURE, run.getResult());
+            finalNodeId[0] = run.getExecution().getCurrentHeads().get(0).getId();
+        });
+        story.then(j-> {
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+            Assert.assertEquals(finalNodeId[0], run.getExecution().getCurrentHeads().get(0).getId());
+            // JENKINS-50199, verify it doesn't try to resume again
+        });
+    }
+
+    @Test
+    public void inProgressButFlowNodesLost() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            FileUtils.deleteDirectory(((CpsFlowExecution)(run.getExecution())).getStorageDir());
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Test
+    /** Build okay but program fails to load */
+    public void inProgressButProgramLoadFailure() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            Method m = cpsExec.getClass().getDeclaredMethod("getProgramDataFile", null);
+            m.setAccessible(true);
+            File f = (File)(m.invoke(cpsExec, null));
+            f.delete();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Test
+    /** Build okay but then the start nodes get screwed up */
+    public void inProgressButStartBlocksLost() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            getCpsBlockStartNodes(cpsExec).push(new FlowStartNode(cpsExec, cpsExec.iotaStr()));
+            run.save();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Test
+    @Issue("JENKINS-50199")
+    /** Replicates case where builds resume when the should not due to build's completion not being saved. */
+    public void completedExecutionButRunIncomplete() throws Exception {
+        final int[] build = new int[1];
+        story.thenWithHardShutdown( j -> {
+            WorkflowRun run = runBasicPauseOnInput(j, DEFAULT_JOBNAME, build);
+            CpsFlowExecution cpsExec = (CpsFlowExecution)(run.getExecution());
+            InputStepExecution exec = getInputStepExecution(run, "pause");
+            exec.doProceedEmpty();
+            j.waitForCompletion(run);
+
+
+            // Set run back to being incomplete as if persistence failed
+            Field completedField = run.getClass().getDeclaredField("completed");
+            completedField.setAccessible(true);
+            completedField.set(run, false);
+
+            Field resultField = Run.class.getDeclaredField("result");
+            resultField.setAccessible(true);
+            resultField.set(run, null);
+
+            run.save();
+        });
+        story.then( j->{
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+        story.then( j->{ // Once more, just to be sure it sticks
+            WorkflowJob r = j.jenkins.getItemByFullName(DEFAULT_JOBNAME, WorkflowJob.class);
+            WorkflowRun run = r.getBuildByNumber(build[0]);
+            assertCompletedCleanly(run);
+        });
+    }
+
+    @Issue("JENKINS-50888")  // Tried to modify build without lazy load being triggered
+    @Test public void modifyBeforeLazyLoad() {
+        story.then(r -> {  // Normal build
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("echo 'dosomething'", true));
+            r.buildAndAssertSuccess(p);
+        });
+        story.then(r -> {  // But wait, we try to modify the build without loading the execution
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            b.setDescription("Bob");
+            b.save();  // Before the JENKINS-50888 fix this would trigger an IOException
+        });
+        story.then( r-> {  // Verify that the FlowExecutionOwner can trigger lazy-load correctly
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            Assert.assertEquals("Bob", b.getDescription());
+            Assert.assertEquals("4", b.getExecution().getCurrentHeads().get(0).getId());
+        });
+    }
+}


### PR DESCRIPTION
[JENKINS-50199](https://issues.jenkins-ci.org/browse/JENKINS-50199).

Should finally put the last variant of this problem to rest.  Root cause: execution completed (and this is saved), but something prevented saving the build *itself* with completed status.   Unfortunately we didn't do anything to detect this case and mark the build itself as completed if its execution was. 

Solving the save itself is a separate problem - since that can potentially be a result of I/O failures or abrupt shutdowns, we have to handle the possibility anyway.

Also adds in the suite of persistence problem tests from the CPS plugin, since *both* the CPS and workflow plugins need to have persistence logic correct internally (and we need to verify this since either can break it). 