### PR TITLE
Should not call our own deprecated method!

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -218,7 +218,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 // TODO to better handle in-VM restart (e.g. in JenkinsRule), move CpsFlowExecution.suspendAll logic into a FlowExecution.notifyShutdown override, then make FlowExecutionOwner.notifyShutdown also overridable, which for WorkflowRun.Owner should listener.close() as needed
                 listener = TaskListenerDecorator.apply(LogStorage.of(asFlowExecutionOwner()).overallListener(), asFlowExecutionOwner(), null);
             } catch (IOException | InterruptedException x) {
-                LOGGER.log(Level.WARNING, "Error trying to open build log file for writing, output will be lost: " + getLogFile(), x);
+                LOGGER.log(Level.WARNING, "Error trying to open build log file for writing, output will be lost: " + this, x);
                 return NULL_LISTENER;
             }
         }
@@ -1078,6 +1078,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return ConsoleNote.removeNotes(logLines);
     }
 
+    @Deprecated
     @Override public File getLogFile() {
         LOGGER.log(Level.WARNING, "Avoid calling getLogFile on " + this, new UnsupportedOperationException());
         try {


### PR DESCRIPTION
Causes a harmless but confusing stack trace when some _other_ exception is being logged.