### PR TITLE
[JENKINS-54128] More efficient implementation of getLogFile that just uses the existing file when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.31</version>
+            <version>2.32-rc862.5f9ac65fd5f2</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/82 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.28</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1089,7 +1089,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             try {
                 f.deleteOnExit();
                 try (OutputStream os = new FileOutputStream(f)) {
-                    getLogText().writeRawLogTo(0, os);
+                    writeLogTo(getLogText()::writeRawLogTo, os);
                 }
             } catch (IOException x) {
                 throw new RuntimeException(x);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1087,12 +1087,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             // FileLogStorage does write a file with the same name and the same format as before JEP-210, so accept it if it is there.
             // This is the normal case if no additional plugin is installed.
         } else {
-            // Some other storage, perhaps cloud-based. Cache under the traditional name, but load from the defined source on each call.
-            try {
-                f.deleteOnExit();
-                try (OutputStream os = new FileOutputStream(f)) {
-                    writeLogTo(getLogText()::writeRawLogTo, os);
-                }
+            // Some other storage, perhaps cloud-based. Load from the defined source on each call, but do not create more than one copy.
+            f = new File(f.getPath() + ".tmp");
+            f.deleteOnExit();
+            try (OutputStream os = new FileOutputStream(f)) {
+                writeLogTo(getLogText()::writeRawLogTo, os);
             } catch (IOException x) {
                 throw new RuntimeException(x);
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1020,7 +1020,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     @Override public InputStream getLogInputStream() throws IOException {
         // Inefficient but probably rarely used anyway.
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        writeLogTo(getLogText()::writeLogTo, baos);
+        writeLogTo(getLogText()::writeRawLogTo, baos);
         return new ByteArrayInputStream(baos.toByteArray());
     }
 
@@ -1085,8 +1085,9 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         File f = super.getLogFile();
         if (LogStorage.of(asFlowExecutionOwner()) instanceof FileLogStorage) {
             // FileLogStorage does write a file with the same name and the same format as before JEP-210, so accept it if it is there.
+            // This is the normal case if no additional plugin is installed.
         } else {
-            // Some other storage. Cache under the traditional name, but load from the defined source on each call.
+            // Some other storage, perhaps cloud-based. Cache under the traditional name, but load from the defined source on each call.
             try {
                 f.deleteOnExit();
                 try (OutputStream os = new FileOutputStream(f)) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -82,6 +82,7 @@ import org.jvnet.hudson.test.recipes.LocalData;
 import org.xml.sax.SAXException;
 
 import javax.annotation.Nonnull;
+import org.apache.commons.io.IOUtils;
 
 public class WorkflowRunTest {
 
@@ -501,6 +502,15 @@ public class WorkflowRunTest {
         String message = "¡Čau → there!";
         p.setDefinition(new CpsFlowDefinition("echo '" + message + "'", true));
         r.assertLogContains(message, r.buildAndAssertSuccess(p));
+    }
+
+    @Issue("JENKINS-54128")
+    @SuppressWarnings("deprecation")
+    @Test public void getLogFile() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("echo 'sample text'", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        assertEquals(IOUtils.toString(b.getLogInputStream()), FileUtils.readFileToString(b.getLogFile()));
     }
 
 }


### PR DESCRIPTION
[JENKINS-54128](https://issues.jenkins-ci.org/browse/JENKINS-54128) Some plugins apparently call this a _lot_ so deal with it.