### PR TITLE
[JENKINS-54904] CSSStyleSheet.rules → cssRules

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -34,13 +34,13 @@ function showHidePipelineSection(link) {
     var showHide = function(id, display) {
         var sect = '.pipeline-node-' + id
         var ss = document.styleSheets[0]
-        for (var i = 0; i < ss.rules.length; i++) {
-            if (ss.rules[i].selectorText === sect) {
-                ss.rules[i].style.display = display
+        for (var i = 0; i < ss.cssRules.length; i++) {
+            if (ss.cssRules[i].selectorText === sect) {
+                ss.cssRules[i].style.display = display
                 return
             }
         }
-        ss.insertRule(sect + ' {display: ' + display + '}', ss.rules.length)
+        ss.insertRule(sect + ' {display: ' + display + '}', ss.cssRules.length)
     }
     showHide(id, display)
     if (span.getAttribute('startId') != null) {


### PR DESCRIPTION
[JENKINS-54904](https://issues.jenkins-ci.org/browse/JENKINS-54904)

The [spec](https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-cssRules) says `cssRules`. Apparently Chrome, but not Firefox, also accepts `rules`, though I can find no documentation about that. :man_shrugging: