### PR TITLE
Remove some no-op overrides

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/AfterRestartTask.java
@@ -28,7 +28,6 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Queue.FlyweightTask;
-import hudson.model.queue.CauseOfBlockage;
 import java.io.IOException;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -51,18 +50,6 @@ class AfterRestartTask implements Queue.FlyweightTask, Queue.TransientTask {
 
     @Override public int hashCode() {
         return getClass().hashCode() ^ run.hashCode();
-    }
-
-    // TODO delete after baseline has https://github.com/jenkinsci/jenkins/pull/3099
-    @Override public boolean isBuildBlocked() {
-        return getCauseOfBlockage() != null;
-    }
-
-    // TODO delete after baseline has https://github.com/jenkinsci/jenkins/pull/3099
-    @Deprecated
-    @Override public String getWhyBlocked() {
-        CauseOfBlockage causeOfBlockage = getCauseOfBlockage();
-        return causeOfBlockage != null ? causeOfBlockage.getShortDescription() : null;
     }
 
     @Override public String getName() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -302,18 +302,6 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         save();
     }
 
-    // TODO delete after baseline has https://github.com/jenkinsci/jenkins/pull/3099
-    @Override public boolean isBuildBlocked() {
-        return getCauseOfBlockage() != null;
-    }
-
-    // TODO delete after baseline has https://github.com/jenkinsci/jenkins/pull/3099
-    @Deprecated
-    @Override public String getWhyBlocked() {
-        CauseOfBlockage c = getCauseOfBlockage();
-        return c != null ? c.getShortDescription() : null;
-    }
-
     @Override public CauseOfBlockage getCauseOfBlockage() {
         if (isLogUpdated() && !isConcurrentBuild()) {
             WorkflowRun lastBuild = getLastBuild();


### PR DESCRIPTION
I was perusing the source tree while debugging an unrelated issue and came across these TODOs. The TODOs were added in jenkinsci/workflow-job-plugin#79, which removed some unnecessary overrides noticed as part of jenkinsci/jenkins#3099 but left these since `workflow-job`'s baseline at the time (2.72) did not yet have jenkinsci/jenkins#3099. jenkinsci/jenkins#3099 shipped in 2.100 (non-LTS) and 2.107 (LTS), as reported by `git tag --contains 5e6b1050b2`. `workflow-job`'s baseline is now Jenkins 2.121.1, which _does_ contain jenkinsci/jenkins#3099. So now we can complete these TODOs.

To test this change, I ran `mvn clean package` locally. It passed. Please let me know if there is any additional testing I should do.