### PR TITLE
Fix prefix ending up outside of console

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -37,7 +37,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
             var branch = label.substring(8)
             var ss = document.styleSheets[0]
             // TODO https://stackoverflow.com/a/18990994/12916 does not scale well to add width: 25em; text-align: right
-            ss.insertRule('.pipeline-node-' + nodeId + '::before {content: "[' + branch.escapeHTML() + '] "; color: #9A9999; position: absolute; transform: translateX(-100%)}', ss.cssRules == null ? 0 : ss.cssRules.length)
+            ss.insertRule('.pipeline-node-' + nodeId + '::before {content: "[' + branch.escapeHTML() + '] "; color: #9A9999; position: relative; transform: translateX(-100%)}', ss.cssRules == null ? 0 : ss.cssRules.length)
             break
         }
     }


### PR DESCRIPTION
Pipeline prefixes how it looked in 2.25
![pipeline_prefix_how_it_looks_in_2 25](https://user-images.githubusercontent.com/19290434/54265116-dabf3e00-4574-11e9-9f12-d95c629c4cfd.png)

How it looks in 2.32
![pipeline_prefix_bug_2](https://user-images.githubusercontent.com/19290434/54265176-004c4780-4575-11e9-86b2-1d39471970c8.png)

This might be somewhat ok with short prefixes but with long ones it becomes hard to read.
![pipeline_prefix_bug](https://user-images.githubusercontent.com/19290434/54265231-1e19ac80-4575-11e9-8569-3cf90b65bded.png)

It's a very small change to make it look like in 2.25. 
