### PR TITLE
Makes WorkflowRun.checkouts() public

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -758,7 +758,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         return isBuilding(); // there is no equivalent to a post-production state for flows
     }
 
-    synchronized @Nonnull List<SCMCheckout> checkouts(@CheckForNull TaskListener listener) {
+    @Exported
+    public synchronized @Nonnull List<SCMCheckout> checkouts(@CheckForNull TaskListener listener) {
         if (checkouts == null) {
             LOGGER.log(Level.WARNING, "JENKINS-26761: no checkouts in {0}", this);
             if (listener != null) {


### PR DESCRIPTION
Allows plugins to access the SCMs in the current pipeline run. Currently the next best option is `WorkflowJob.getSCMs()`, which gets the SCMs of the _previous_ run.