### PR TITLE
[JENKINS-46076] Reordering events so WorkflowRun.completed not set until finish cause printed & log closed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.40</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -195,7 +195,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     /** True when first started, false when running after a restart. */
     private transient boolean firstTime;
 
-    /** Obtain our guard object for log copying, lazily initializing if needed.
+    /** Obtain our guard object for metadata, lazily initializing if needed.
      *  Note: to avoid deadlocks, when nesting locks we ALWAYS need to lock on the guard first, THEN the WorkflowRun.
      *  Synchronizing this helps ensure that fields are not mutated during a {@link #save()} operation, since that locks on the Run.
      */
@@ -211,8 +211,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     /** Used internally to ensure listener has been initialized correctly. */
     BuildListener getListener() {
-        // Un-synchronized to prevent deadlocks (combination of run and logCopyGuard)
-        // Note that in portions where multithreaded access is possible we are already synchronizing on logCopyGuard
+        // Un-synchronized to prevent deadlocks (combination of run and metadataGuard)
+        // Note that in portions where multithreaded access is possible we are already synchronizing on metadataGuard
         if (listener == null) {
             try {
                 // TODO to better handle in-VM restart (e.g. in JenkinsRule), move CpsFlowExecution.suspendAll logic into a FlowExecution.notifyShutdown override, then make FlowExecutionOwner.notifyShutdown also overridable, which for WorkflowRun.Owner should listener.close() as needed

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -753,7 +753,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @Override public boolean isLogUpdated() {
-        return isBuilding(); // there is no equivalent to a post-production state for flows
+        return listener != null || isBuilding(); // there is no equivalent to a post-production state for flows
     }
 
     synchronized @Nonnull List<SCMCheckout> checkouts(@CheckForNull TaskListener listener) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -196,7 +196,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     private transient boolean firstTime;
 
     /** Obtain our guard object for log copying, lazily initializing if needed.
-     *  Note: to avoid deadlocks, when nesting locks we ALWAYS need to lock on the logCopyGuard first, THEN the WorkflowRun.
+     *  Note: to avoid deadlocks, when nesting locks we ALWAYS need to lock on the guard first, THEN the WorkflowRun.
      *  Synchronizing this helps ensure that fields are not mutated during a {@link #save()} operation, since that locks on the Run.
      */
     private synchronized Object getMetadataGuard() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -572,6 +572,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     private void finish(@Nonnull Result r, @CheckForNull Throwable t) {
         try {
             setResult(r);
+            duration = Math.max(0, System.currentTimeMillis() - getStartTimeInMillis());
             LOGGER.log(Level.INFO, "{0} completed: {1}", new Object[]{toString(), getResult()});
             if (listener == null) {
                 // Never even made it to running, either failed when fresh-started or resumed -- otherwise getListener would have run
@@ -597,7 +598,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             }
             synchronized (getLogCopyGuard()) {
                 completed = true;
-                duration = Math.max(0, System.currentTimeMillis() - getStartTimeInMillis());
             }
             saveWithoutFailing(); // TODO useless if we are inside a BulkChange
             Timer.get().submit(() -> {


### PR DESCRIPTION
[JENKINS-46076](https://issues.jenkins-ci.org/browse/JENKINS-46076)

After incremental deployment, downstream bumps in:
- [X] https://github.com/jenkinsci/workflow-cps-plugin/pull/294
- [X] https://github.com/jenkinsci/kubernetes-plugin/pull/496
- [X] https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/336