### PR TITLE
Use Functions.printStackTrace

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -629,7 +629,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
             } catch (AbortException x) {
                 listener.error("polling failed in " + co.workspace + " on " + co.node + ": " + x.getMessage());
             } catch (Exception x) {
-                listener.error("polling failed in " + co.workspace + " on " + co.node).println(Functions.printThrowable(x).trim()); // TODO 2.43+ use Functions.printStackTrace
+                Functions.printStackTrace(x, listener.error("polling failed in " + co.workspace + " on " + co.node));
             }
         }
         return result;


### PR DESCRIPTION
In #38, a call to `Functions.printThrowable` was added with a TODO comment to switch to `Functions.printStackTrace` when the baseline was bumped to 2.43+. The baseline is now 2.121.1, so this TODO can be completed.

This code doesn't appear to have any test coverage, but I feel confident about the change based on the similar logic that is present in `WorkflowRun` and the testing I did for a similar change in jenkinsci/workflow-basic-steps-plugin#91.