### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/CLITest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/CLITest.java
@@ -54,7 +54,7 @@ public class CLITest {
 
     @Test public void listChanges() throws Exception {
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("node {def s = new org.jvnet.hudson.test.FakeChangeLogSCM(); s.addChange().withAuthor('alice').withMsg('hello'); checkout s}", false));
+        p.setDefinition(new CpsFlowDefinition("node {def s = new org.jvnet.hudson.test.FakeChangeLogSCM(); s.addChange().withAuthor('alice').withMsg('hello'); checkout s}", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
         r.buildAndAssertSuccess(p);
         CLICommandInvoker.Result res = new CLICommandInvoker(r, "list-changes").invokeWithArgs("p", "1");
         assertThat(res, CLICommandInvoker.Matcher.succeeded());

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
@@ -29,20 +29,20 @@ public class WorkflowJobTest {
         p.setDefinition(new CpsFlowDefinition(
             "node {\n" +
                     "  checkout(new hudson.scm.NullSCM())\n" +
-            "}"));
+            "}", false /* for hudson.scm.NullSCM */));
         assertTrue("No runs has been performed and there should be no SCMs", p.getSCMs().isEmpty());
 
         j.buildAndAssertSuccess(p);
 
         assertEquals("Expecting one SCM", 1, p.getSCMs().size());
 
-        p.setDefinition(new CpsFlowDefinition("error 'Fail!'"));
+        p.setDefinition(new CpsFlowDefinition("error 'Fail!'", true));
 
         j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
 
         assertEquals("Expecting one SCM even though last run failed",1, p.getSCMs().size());
 
-        p.setDefinition(new CpsFlowDefinition("echo 'Pass!'"));
+        p.setDefinition(new CpsFlowDefinition("echo 'Pass!'", true));
 
         j.buildAndAssertSuccess(p);
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -92,7 +92,7 @@ public class WorkflowRunTest {
 
     @Test public void basics() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("println('hello')"));
+        p.setDefinition(new CpsFlowDefinition("println('hello')", true));
         WorkflowRun b1 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertFalse(b1.isBuilding());
         assertFalse(b1.isInProgress());
@@ -150,8 +150,8 @@ public class WorkflowRunTest {
         p.setDefinition(new CpsFlowDefinition(
             "println('hello')\n"+
             "semaphore 'wait'\n"+
-            "println('hello')\n"
-        ));
+            "println('hello')\n",
+            true));
 
         // no build exists yet
         assertSame(p.getIconColor(),BallColor.NOTBUILT);
@@ -227,7 +227,7 @@ public class WorkflowRunTest {
         final WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         final String groovy = "println 'hello'";
         try (ACLContext context = ACL.as(User.getById("dev", true))) {
-            p.setDefinition(new CpsFlowDefinition(groovy));
+            p.setDefinition(new CpsFlowDefinition(groovy, false /* for mock authorization strategy */));
         }
         r.assertLogContains("UnapprovedUsageException", r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get()));
         Set<ScriptApproval.PendingScript> pendingScripts = ScriptApproval.get().getPendingScripts();
@@ -248,8 +248,8 @@ public class WorkflowRunTest {
                         "def hello = new HelloWorld()\n" +
                         "public class HelloWorld()\n" +
                         "{ // <- invalid class definition }\n" +
-                        "}}"
-        ));
+                        "}}",
+                true));
         QueueTaskFuture<WorkflowRun> workflowRunQueueTaskFuture = p.scheduleBuild2(0);
         WorkflowRun run = r.assertBuildStatus(Result.FAILURE, workflowRunQueueTaskFuture.get());
 
@@ -264,7 +264,7 @@ public class WorkflowRunTest {
     @Test public void buildRecordAfterRename() throws Exception {
         {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p1");
-            p.setDefinition(new CpsFlowDefinition("echo 'hello world'"));
+            p.setDefinition(new CpsFlowDefinition("echo 'hello world'", true));
             r.assertBuildStatusSuccess(p.scheduleBuild2(0));
             p.renameTo("p2");
         }
@@ -372,7 +372,7 @@ public class WorkflowRunTest {
                 "    def thirdScm = new FakeChangeLogSCM()\n" +
                 "    thirdScm.addChange().withAuthor(/charlie$BUILD_NUMBER/)\n" +
                 "    checkout(thirdScm)\n" +
-                "}\n", false));
+                "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DurabilityHintJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DurabilityHintJobPropertyTest.java
@@ -22,7 +22,7 @@ public class DurabilityHintJobPropertyTest {
     @Test
     public void configRoundTripAndRun() throws Exception{
         WorkflowJob defaultCase = r.jenkins.createProject(WorkflowJob.class, "testCase");
-        defaultCase.setDefinition(new CpsFlowDefinition("echo 'cheese is delicious'", false));
+        defaultCase.setDefinition(new CpsFlowDefinition("echo 'cheese is delicious'", true));
 
         assertNull(defaultCase.getProperty(DurabilityHintJobProperty.class));
 


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the CpsFlowDefinitions in the tests don't consistently use the script security sandbox. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production.

I did the following in this change:

- In any case where the deprecated single-argument constructor for `CpsFlowDefinition` was used, I switched to the non-deprecated two-argument constructor (which takes a boolean as the second argument to determine whether to enable the script security sandbox).
- Wherever the script security sandbox could be enabled, I enabled it.
- Wherever the script security sandbox couldn't be enabled, I added a comment explaining why. This seemed preferable to approving all the relevant methods the test used, which could be fragile since many of those methods are implementation details of classes outside of this project.