### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/views/GraphVizAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/views/GraphVizAction.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.job.views;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.util.HttpResponses;
@@ -76,7 +77,7 @@ public final class GraphVizAction implements Action {
         return HttpResponses.plainText(sw.toString());
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public void doIndex(StaplerResponse rsp) throws IOException {
         Process p = new ProcessBuilder("dot", "-Tpng").start();
         writeDot(new PrintWriter(p.getOutputStream()));

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -444,10 +444,10 @@ public class WorkflowRunTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("", true));
         // Control case:
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap("p", User.get("admin").impersonate())));
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(new MockQueueItemAuthenticator(Collections.singletonMap("p", User.getById("admin", true).impersonate())));
         r.buildAndAssertSuccess(p);
         // Test case: build is never scheduled, queue item hangs with “Waiting for next available executor on master”
-        QueueItemAuthenticatorConfiguration.get().getAuthenticators().replace(new MockQueueItemAuthenticator(Collections.singletonMap("p", User.get("dev").impersonate())));
+        QueueItemAuthenticatorConfiguration.get().getAuthenticators().replace(new MockQueueItemAuthenticator(Collections.singletonMap("p", User.getById("dev", true).impersonate())));
         r.buildAndAssertSuccess(p);
     }
 


### PR DESCRIPTION
While perusing the source tree, I noticed some deprecated methods:

- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID.
- The documentation for [`edu.umd.cs.findbugs.annotations.SuppressWarnings`](http://findbugs.sourceforge.net/api/edu/umd/cs/findbugs/annotations/SuppressWarnings.html) states: "Was used to suppress FindBugs warnings but generates name conflicts with `SuppressWarnings`".

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, and I replaced any usages of `edu.umd.cs.findbugs.annotations.SuppressWarnings` with usages of `edu.umd.cs.findbugs.annotations.SuppressFBWarnings`.