### PR TITLE
Add missing Override annotations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -671,34 +671,29 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         /**
          * Needed if it wants Pipeline jobs are categorized in Jenkins 2.x.
          *
-         * TODO: Override when the baseline is upgraded to 2.x
          * TODO: Replace to {@code StandaloneProjectsCategory.ID}
          *
          * @return A string it represents a ItemCategory identifier.
          */
-        public String getCategoryId() {
+        @Override public String getCategoryId() {
             return "standalone-projects";
         }
 
         /**
          * Needed if it wants Pipeline jobs are categorized in Jenkins 2.x.
          *
-         * TODO: Override when the baseline is upgraded to 2.x
-         *
          * @return A string with the Item description.
          */
-        public String getDescription() {
+        @Override public String getDescription() {
             return Messages.WorkflowJob_Description();
         }
 
         /**
          * Needed if it wants Pipeline jobs are categorized in Jenkins 2.x.
          *
-         * TODO: Override when the baseline is upgraded to 2.x
-         *
          * @return A string it represents a URL pattern to get the Item icon in different sizes.
          */
-        public String getIconFilePathPattern() {
+        @Override public String getIconFilePathPattern() {
             return "plugin/workflow-job/images/:size/pipelinejob.png";
         }
 


### PR DESCRIPTION
In e8cad2297f6af419eb28cd31ec8218c4b9b3ba5a three TODO comments were left stating: "TODO: Override when the baseline is upgraded to 2.x". The baseline is now 2.121.1, so these TODOs can be completed. I did so by adding the missing annotations.