### PR TITLE
Wait for program to be persisted in runBasicPauseOnInput

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/CpsPersistenceTest.java
@@ -171,6 +171,7 @@ public class CpsPersistenceTest {
             System.out.println("Waiting for input action to get attached to run");
             Thread.sleep(50);
         }
+        Thread.sleep(100L);  // A little extra buffer for persistence etc
         if (durabilityHint != FlowDurabilityHint.PERFORMANCE_OPTIMIZED) {
             CpsFlowExecution execution = (CpsFlowExecution) run.getExecution();
             Method m = execution.getClass().getDeclaredMethod("getProgramDataFile", null);


### PR DESCRIPTION
See [#136 (comment)](https://github.com/jenkinsci/workflow-job-plugin/pull/136/files/57dd3f4971b2550146349a03fa6ff7f240e91bb4#r318151753). Some code cleanup in `CpsPersistenceTest` revealed that the test had never been working deterministically in the first place. By removing the `Thread.sleep(100L)` on line 174 of `CpsPersistenceTest`, I was able to reliably reproduce the failure @dwnusbaum mentioned. Looking into it further, an arbitrary 100ms sleep is inherently racy. We really want to wait until the program is persisted before returning to ensure this method is deterministic. Although there exist methods such as `CpsThreadGroup#saveProgram` to save the program, those methods can only be called from the CPS VM thread and it's not practical to invoke them from `workflow-job`'s tests. Instead I chose to wait for the program data file to be present on the file system. While this necessitates a bit of ugly reflection, it's no worse than what's done elsewhere in this class. With this fix in place, I ran the failing test 160 times in a row without seeing any failures.