### PR TITLE
FlowExecutionListener fireCompleted before logs are closed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.36</version>
+            <version>2.38-rc936.17c216ce6a16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -593,6 +593,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     Functions.printStackTrace(t, getListener().getLogger());
                 }
                 getListener().finished(getResult());
+                fireBeforeCompletedFlowExecutionListener();
                 if (listener instanceof AutoCloseable) {
                     try {
                         ((AutoCloseable) listener).close();
@@ -620,6 +621,17 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         } catch (IOException | InterruptedException x) {
             LOGGER.log(Level.WARNING, "failed to clean up stashes from " + this, x);
         }
+        fireOnCompletedFlowExecutionListener();
+    }
+
+    private void fireBeforeCompletedFlowExecutionListener(){
+        FlowExecution exec = getExecution();
+        if (exec != null) {
+            FlowExecutionListener.fireBeforeCompleted(exec);
+        }
+    }
+
+    private void fireOnCompletedFlowExecutionListener(){
         FlowExecution exec = getExecution();
         if (exec != null) {
             FlowExecutionListener.fireCompleted(exec);


### PR DESCRIPTION
When writing to logs within *FlowExecutionListener.onCompleted* using this:

`owner.getListener().getLogger().println("blah blah blah");`

and exception is raised

java.lang.IllegalStateException: trying to open a build log on timeout-too-long-with-error #1 after it has completed
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getListener(WorkflowRun.java:219)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.access$300(WorkflowRun.java:133)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.getListener(WorkflowRun.java:955)
        at myListener(...)

In order to fix that, 

`FlowExecutionListener.fireCompleted(exec);`

should be executed before closing the stream and finishing the execution.

In this PR, the execution happens before closing the listener.
