### PR TITLE
[JENKINS-60354] Mark thrown FlowInterruptedExceptions as actual interruptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.20</version>
+            <version>2.22-rc550.2870bd01d2ff</version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -406,7 +406,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         if (!isInProgress() || /* redundant, but make FindBugs happy */ execution == null) {
             return;
         }
-        final Throwable x = new FlowInterruptedException(Result.ABORTED);
+        final Throwable x = new FlowInterruptedException(Result.ABORTED, true);
         FlowExecution exec = getExecution();
         if (exec == null) { // Already dead, just make sure statuses reflect that.
             synchronized (getMetadataGuard()) {
@@ -461,7 +461,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             execution = null; // ensures isInProgress returns false
             executionLoaded = true;
         }
-        FlowInterruptedException suddenDeath = new FlowInterruptedException(Result.ABORTED);
+        FlowInterruptedException suddenDeath = new FlowInterruptedException(Result.ABORTED, true);
         finish(Result.ABORTED, suddenDeath);
         getSettableExecutionPromise().setException(suddenDeath);
         // TODO CpsFlowExecution.onProgramEnd does some cleanup which we cannot access here; perhaps need a FlowExecution.halt(Throwable) API?


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.