### PR TITLE
[JENKINS-61415] Remove polling baselines from Pipelines when the SCM has no polling baseline

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -642,8 +642,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
                         job.pollingBaselines = new ConcurrentHashMap<>();
                     }
                     job.pollingBaselines.put(scm.getKey(), pollingBaseline);
-                }
-                else{
+                } else {
                     //pollingBaseline is null here
                     if (job.pollingBaselines != null) {
                         // We need to remove the polling baseline if the baseline goes back to null

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -386,7 +386,7 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
      */
     @Deprecated
     public static final Permission ABORT = CANCEL;
-    
+
     @Override public Collection<? extends SubTask> getSubTasks() {
         // TODO mostly copied from AbstractProject, except SubTaskContributor is not available:
         List<SubTask> subTasks = new ArrayList<>();
@@ -591,7 +591,6 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
                 FilePath workspace;
                 Launcher launcher;
                 WorkspaceList.Lease lease;
-
                 if (co.scm.requiresWorkspaceForPolling()) {
                     Jenkins j = Jenkins.getInstanceOrNull();
                     if (j == null) {
@@ -637,19 +636,10 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         @Override public void onCheckout(Run<?,?> build, SCM scm, FilePath workspace, TaskListener listener, File changelogFile, SCMRevisionState pollingBaseline) throws Exception {
             if (build instanceof WorkflowRun) {
                 WorkflowJob job = ((WorkflowRun) build).getParent();
-                if (pollingBaseline != null) {
-                    if (job.pollingBaselines == null) {
-                        job.pollingBaselines = new ConcurrentHashMap<>();
-                    }
-                    job.pollingBaselines.put(scm.getKey(), pollingBaseline);
-                } else {
-                    //pollingBaseline is null here
-                    if (job.pollingBaselines != null) {
-                        // We need to remove the polling baseline if the baseline goes back to null
-                        // this is caused by the checkout/polling values becoming false
-                        job.pollingBaselines.remove(scm.getKey());
-                    }
+                if (job.pollingBaselines == null) {
+                    job.pollingBaselines = new ConcurrentHashMap<>();
                 }
+                job.pollingBaselines.compute(scm.getKey(), (key, oldBaseline) -> pollingBaseline);
             }
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -72,6 +72,8 @@ import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -504,40 +506,27 @@ public class WorkflowRunTest {
         sampleRepo.init();
         TaskListener listener = StreamTaskListener.fromStdout();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, true, true) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-
-        SemaphoreStep.waitForStart("waitFirst/1", b1);
-        SemaphoreStep.success("waitFirst/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b1));
-        for (WorkflowRun.SCMCheckout co : b1.checkouts(listener)){
-            System.out.println("Checkout: " + co.toString());
-            assertTrue(co.pollingBaseline != null);
-        }
+        assertThat(b1.checkouts(listener).size(), equalTo(1));
+        assertThat(b1.checkouts(listener).get(0).pollingBaseline, notNullValue());
 
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, false, false) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
         WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
 
-        SemaphoreStep.waitForStart("waitFirst/2", b2);
-        SemaphoreStep.success("waitFirst/2", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b2));
-        for (WorkflowRun.SCMCheckout co : b2.checkouts(listener)){
-            assertTrue(co.pollingBaseline == null);
-        }
+        assertThat(b2.checkouts(listener).size(), equalTo(1));
+        assertThat(b2.checkouts(listener).get(0).pollingBaseline, nullValue());
     }
 
     @Test
@@ -547,74 +536,50 @@ public class WorkflowRunTest {
         sampleRepo.init();
         TaskListener listener = StreamTaskListener.fromStdout();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, true, true) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-
-        SemaphoreStep.waitForStart("waitFirst/1", b1);
-        SemaphoreStep.success("waitFirst/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b1));
-        for (WorkflowRun.SCMCheckout co : b1.checkouts(listener)){
-            System.out.println("Checkout: " + co.toString());
-            assertTrue(co.pollingBaseline != null);
-        }
+        assertThat(b1.checkouts(listener).size(), equalTo(1));
+        assertThat(b1.checkouts(listener).get(0).pollingBaseline, notNullValue());
 
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + false +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, false, true) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
         WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
 
-        SemaphoreStep.waitForStart("waitFirst/2", b2);
-        SemaphoreStep.success("waitFirst/2", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b2));
-        for (WorkflowRun.SCMCheckout co : b2.checkouts(listener)){
-            assertTrue(co.pollingBaseline != null);
-        }
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        assertThat(b2.checkouts(listener).size(), equalTo(1));
+        assertThat(b2.checkouts(listener).get(0).pollingBaseline, notNullValue());
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + true +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, true, false) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
         WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
 
-        SemaphoreStep.waitForStart("waitFirst/3", b3);
-        SemaphoreStep.success("waitFirst/3", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b3));
-        for (WorkflowRun.SCMCheckout co : b3.checkouts(listener)){
-            assertTrue(co.pollingBaseline != null);
-        }
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        assertThat(b3.checkouts(listener).size(), equalTo(1));
+        assertThat(b3.checkouts(listener).get(0).pollingBaseline, notNullValue());
+
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
+                checkoutString(sampleRepo, false, false) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
         WorkflowRun b4 = p.scheduleBuild2(0).waitForStart();
 
-        SemaphoreStep.waitForStart("waitFirst/4", b4);
-        SemaphoreStep.success("waitFirst/4", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b4));
-        for (WorkflowRun.SCMCheckout co : b4.checkouts(listener)){
-            assertTrue(co.pollingBaseline == null);
-        }
+        assertThat(b4.checkouts(listener).size(), equalTo(1));
+        assertThat(b4.checkouts(listener).get(0).pollingBaseline, nullValue());
     }
 
     @Test
@@ -623,75 +588,102 @@ public class WorkflowRunTest {
     public void baselineResetMultipleRepos() throws Exception {
         sampleRepo.init();
         sampleRepo2.init();
+        System.out.println("Repo file URL at: " + sampleRepo.fileUrl());
         TaskListener listener = StreamTaskListener.fromStdout();
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
-                "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
+                checkoutString(sampleRepo, true, true) +
+                checkoutString(sampleRepo2, true, true) +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-
-        SemaphoreStep.waitForStart("waitFirst/1", b1);
-        SemaphoreStep.success("waitFirst/1", null);
         r.assertBuildStatusSuccess(r.waitForCompletion(b1));
-        for (WorkflowRun.SCMCheckout co : b1.checkouts(listener)){
-            System.out.println("Checkout: " + co.toString());
-            assertTrue(co.pollingBaseline != null);
-        }
+        assertThat(b1.checkouts(listener).size(), equalTo(2));
+        assertThat(b1.checkouts(listener).get(0).pollingBaseline, notNullValue());
+        assertThat(b1.checkouts(listener).get(1).pollingBaseline, notNullValue());
 
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
-                "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
-                "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
+                checkoutString(sampleRepo, false, false) +
+                checkoutString(sampleRepo2, true, true) +
+                "}\n", false));
 
 
         WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
 
-        SemaphoreStep.waitForStart("waitFirst/2", b2);
-        SemaphoreStep.success("waitFirst/2", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b2));
-        int count = 0;
-        for (WorkflowRun.SCMCheckout co : b2.checkouts(listener)){
-            if(count == 0) {
-                assertTrue(co.pollingBaseline == null);
-                count++;
-            } else {
-                assertTrue(co.pollingBaseline != null);
-            }
-        }
+        assertThat(b2.checkouts(listener).size(), equalTo(2));
+        assertThat(b2.checkouts(listener).get(0).pollingBaseline, nullValue());
+        assertThat(b2.checkouts(listener).get(1).pollingBaseline, notNullValue());
 
-        p.setDefinition(new CpsFlowDefinition("semaphore 'waitFirst'\n" +
+        p.setDefinition(new CpsFlowDefinition(
                 "node {\n" +
-                "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
-                "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
-                "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
+                checkoutString(sampleRepo, false, false) +
+                checkoutString(sampleRepo2, false, false) +
+                "}\n", false));
 
 
         WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
-
-        SemaphoreStep.waitForStart("waitFirst/3", b3);
-        SemaphoreStep.success("waitFirst/3", null);
-
         r.assertBuildStatusSuccess(r.waitForCompletion(b3));
-        for (WorkflowRun.SCMCheckout co : b3.checkouts(listener)){
-            assertTrue(co.pollingBaseline == null);
-        }
+        assertThat(b3.checkouts(listener).size(), equalTo(2));
+        assertThat(b3.checkouts(listener).get(0).pollingBaseline, nullValue());
+        assertThat(b3.checkouts(listener).get(1).pollingBaseline, nullValue());
+    }
+
+    @Test
+    @Issue("NGPIPELINE-917")
+    // Basic test to prove that checkout gets individually set for each checkout
+    public void baselineResetMultipleSameRepo() throws Exception {
+        sampleRepo.init();
+        sampleRepo2.init();
+        System.out.println("Repo file URL at: " + sampleRepo.fileUrl());
+        TaskListener listener = StreamTaskListener.fromStdout();
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        checkoutString(sampleRepo, true, true) +
+                        checkoutString(sampleRepo, true, true) +
+                        "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
+
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatusSuccess(r.waitForCompletion(b1));
+        assertThat(b1.checkouts(listener).size(), equalTo(2));
+        assertThat(b1.checkouts(listener).get(0).pollingBaseline, notNullValue());
+        assertThat(b1.checkouts(listener).get(1).pollingBaseline, notNullValue());
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        checkoutString(sampleRepo, false, false) +
+                        checkoutString(sampleRepo, true, true) +
+                        "}\n", false));
+
+
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+
+        r.assertBuildStatusSuccess(r.waitForCompletion(b2));
+        assertThat(b2.checkouts(listener).size(), equalTo(2));
+        assertThat(b2.checkouts(listener).get(0).pollingBaseline, nullValue());
+        assertThat(b2.checkouts(listener).get(1).pollingBaseline, notNullValue());
+
+        p.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        checkoutString(sampleRepo, false, false) +
+                        checkoutString(sampleRepo, false, false) +
+                        "}\n", false));
+
+
+        WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+        r.assertBuildStatusSuccess(r.waitForCompletion(b3));
+        assertThat(b3.checkouts(listener).size(), equalTo(2));
+        assertThat(b3.checkouts(listener).get(0).pollingBaseline, nullValue());
+        assertThat(b3.checkouts(listener).get(1).pollingBaseline, nullValue());
+    }
+
+    String checkoutString(GitSampleRepoRule repo, boolean changelog, boolean polling) throws Exception {
+        return "    checkout(changelog:" + changelog +", poll:" + polling +
+                ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
+                ", userRemoteConfigs: [[url: $/" + repo.fileUrl() + "/$]]])\n";
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -96,6 +96,7 @@ public class WorkflowRunTest {
     @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule sampleRepo2 = new GitSampleRepoRule();
 
+
     @Test public void basics() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("println('hello')", true));
@@ -507,7 +508,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -524,7 +525,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
@@ -550,7 +551,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -567,7 +568,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + false +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
@@ -584,7 +585,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + true +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
@@ -601,7 +602,7 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
@@ -628,10 +629,10 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])\n" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
                 "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo2 + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -648,10 +649,10 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])\n" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
                 "    checkout(changelog:" + true +", poll:" + true + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo2 + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 
@@ -675,10 +676,10 @@ public class WorkflowRunTest {
                 "node {\n" +
                 "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo + "']]])\n" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo + "/$]]])\n" +
                 "    checkout(changelog:" + false +", poll:" + false + ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 "doGenerateSubmoduleConfigurations: false, extensions: [], " +
-                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: '" + sampleRepo2 + "']]])" +
+                "gitTool: 'Default', submoduleCfg: [], userRemoteConfigs: [[url: $/" + sampleRepo2 + "/$]]])" +
                 "}\n", false /* for org.jvnet.hudson.test.FakeChangeLogSCM */));
 
 


### PR DESCRIPTION
If you check the changelog or polling  checkbox or make them true, then do a build it will make those checkout endpoints poll-able. But once you uncheck those or mark them false it never takes those endpoints off the possible endpoints to check.

This PR fixes that

It has tests included to prove when and where this works and doesnt work. Eventually I want a better fix as this will just mark it as "no polling baseline" which is not an accurate message