### PR TITLE
Remove debug text from console.jelly

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
       <t:buildCaption>
-        Custom ${%Console Output}
+        ${%Console Output}
       </t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->


### PR DESCRIPTION
I added this text to #150 while testing, but forgot to remove it before filing the PR.