### PR TITLE
Another flake caused by waitForCompletion returning in the middle of WorkflowRun.finish

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -292,6 +292,7 @@ public class WorkflowRunRestartTest {
             SemaphoreStep.success("post-resume/1", null);
 
             r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b));
+            r.waitForMessage("Finished: FAILURE", b);
             r.assertLogContains("Running for listener", b);
 
             assertEquals(0, listener.created);


### PR DESCRIPTION
From from `bom` PCT as usual: https://github.com/jenkinsci/bom/pull/208#issuecomment-611476831. Can be reproduced this way:

```diff
diff --git src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
index 1177ef4..f2aebc3 100644
--- src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -589,6 +589,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             synchronized (getMetadataGuard()) {
                 myListener = getListener();
                 completed = true;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                }
             }
             duration = Math.max(0, System.currentTimeMillis() - getStartTimeInMillis());
             LOGGER.log(Level.INFO, "{0} completed: {1}", new Object[]{toString(), getResult()});
```