### PR TITLE
WorkflowRunRestartTest.resumeDisabled should not assume that the execution is not loaded

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -99,7 +99,6 @@ public class WorkflowRunRestartTest {
             assertTrue(p.isResumeBlocked());
             WorkflowRun b = p.getBuildByNumber(1);
             r.waitForCompletion(b);
-            assertFalse(b.executionLoaded);
             assertTrue(b.completed);
             assertFalse(b.isBuilding());
             assertEquals(Result.ABORTED, b.getResult());


### PR DESCRIPTION
From #159 I see an apparent mistake in #93. The execution is indeed loaded after a restart:

```
java.lang.Exception: Stack trace
	at java.lang.Thread.dumpStack(Thread.java:1336)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:711)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:957)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:65)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$1.computeNext(FlowExecutionList.java:57)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:143)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:138)
	at org.jenkinsci.plugins.workflow.flow.FlowExecutionList$ItemListenerImpl.onLoaded(FlowExecutionList.java:178)
	at jenkins.model.Jenkins.<init>(Jenkins.java:989)
	at …
```

which does not seem improper. The test may have passed accidentally due to a race condition with the restart.