### PR TITLE
[JENKINS-62025] Pipeline console uses JS methods not supported by IE 11

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -43,7 +43,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
             break
         }
         var label = labels.get(id)
-        if (label != null && label.startsWith('Branch: ')) {
+        if (label != null && label.indexOf('Branch: ') == 0) {
             var branch = label.substring(8)
             var ss = document.styleSheets[0]
             // TODO https://stackoverflow.com/a/18990994/12916 does not scale well to add width: 25em; text-align: right

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -7,7 +7,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
     if (label != null) {
         var html = e.innerHTML
         var suffix = ' (' + label.escapeHTML() + ')';
-        if (!html.includes(suffix)) {
+        if (html.indexOf(suffix)<0) {
             e.innerHTML = e.innerHTML.replace(/.+/, '$&' + suffix) // insert before EOL
         }
     }


### PR DESCRIPTION
See [JENKINS-62025](https://issues.jenkins.io/browse/JENKINS-62025).

Signed-off-by: olivier lamy <olamy@apache.org>