### PR TITLE
Replace use of recommendedPlugins with explicit configurations in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(useAci: false, configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(useAci: false, configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: false, configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: "2.222.3" ]
 ])


### PR DESCRIPTION
#163 fixed the build after it was broken by https://github.com/jenkins-infra/pipeline-library/pull/92, but then https://github.com/jenkins-infra/pipeline-library/pull/146 broke it again.

This PR stops using `buildPlugin.recommendedConfigurations` to avoid these kinds of issues in the first place.