### PR TITLE
Fix theming of Keep this build forever action

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
@@ -28,7 +28,7 @@
     <l:layout title="${it.fullDisplayName}">
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
-            <div style="float:right; background-color:white; z-index: 1; position:relative; margin-left: 1em">
+            <div style="float:right; z-index: 1; position:relative; margin-left: 1em">
                 <l:hasPermission permission="${it.UPDATE}">
                     <st:include page="logKeep.jelly"/>
                 </l:hasPermission>


### PR DESCRIPTION
See jenkinsci/dark-theme-plugin#97.

Fixed in core in https://github.com/jenkinsci/jenkins/pull/4814, but code is duplicated here

cc @fqueiruga @dwnusbaum 

Without this change it looks like:

![image](https://user-images.githubusercontent.com/21194782/86569886-01259b80-bf67-11ea-92d1-91d9731b925a.png)
