### PR TITLE
[JENKINS-46961] Prevent Pipelines from resuming after being aborted while starting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>2.83-rc2519.cb8c2b01a48c</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/374 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.83-rc2516.a6a008bb00ac</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/374 -->
+            <version>2.83</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.83-rc2519.cb8c2b01a48c</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/374 -->
+            <version>2.83-rc2516.a6a008bb00ac</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/374 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -213,6 +213,51 @@ public class WorkflowRunRestartTest {
         });
     }
 
+    @Issue("JENKINS-46961")
+    @Test public void interruptedWhileStartingMaxSurvivability() throws Exception {
+        story.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                "import groovy.transform.*\n" +
+                "import hudson.model.Executor\n" +
+                "import hudson.model.Result\n" +
+                "import jenkins.model.CauseOfInterruption\n" +
+                // This runs during CpsFlowExecution.parseScript which runs during CpsFlowExecution.start.
+                "@ASTTest(value={\n" +
+                "  def cause = new CauseOfInterruption.UserInterruption('unknown')\n" +
+                "  Executor.currentExecutor().interrupt(Result.ABORTED, cause) }) _\n", false));
+            WorkflowRun b = r.buildAndAssertStatus(Result.ABORTED, p);
+            r.assertLogContains("Aborted by unknown", b);
+        });
+        story.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getLastBuild();
+            assertFalse("Build should be completed", b.isBuilding());
+        });
+    }
+
+    @Issue("JENKINS-46961")
+    @Test public void interruptedWhileStartingPerformanceOptimized() throws Exception {
+        story.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            p.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.PERFORMANCE_OPTIMIZED));
+            p.setDefinition(new CpsFlowDefinition(
+                "import groovy.transform.*\n" +
+                "import hudson.model.Executor\n" +
+                "import hudson.model.Result\n" +
+                "import jenkins.model.CauseOfInterruption\n" +
+                // This runs during CpsFlowExecution.parseScript which runs during CpsFlowExecution.start.
+                "@ASTTest(value={ Executor.currentExecutor().interrupt(Result.ABORTED, new CauseOfInterruption.UserInterruption('unknown')) }) _\n", false));
+            WorkflowRun b = r.buildAndAssertStatus(Result.ABORTED, p);
+            r.assertLogContains("Aborted by unknown", b);
+        });
+        story.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getLastBuild();
+            assertFalse("Build should be completed", b.isBuilding());
+        });
+    }
+
     private boolean hasTermOrKillLink(WorkflowRun b, String termOrKill) throws Exception {
         return !story.j.createWebClient().getPage(b)
                 .getByXPath("//a[@href = '#' and contains(@onclick, '/" + b.getUrl() + termOrKill + "')]").isEmpty();

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -225,7 +225,8 @@ public class WorkflowRunRestartTest {
                 // This runs during CpsFlowExecution.parseScript which runs during CpsFlowExecution.start.
                 "@ASTTest(value={\n" +
                 "  def cause = new CauseOfInterruption.UserInterruption('unknown')\n" +
-                "  Executor.currentExecutor().interrupt(Result.ABORTED, cause) }) _\n", false));
+                "  Executor.currentExecutor().interrupt(Result.ABORTED, cause)\n" +
+                "}) _\n", false));
             WorkflowRun b = r.buildAndAssertStatus(Result.ABORTED, p);
             r.assertLogContains("Aborted by unknown", b);
         });
@@ -247,7 +248,10 @@ public class WorkflowRunRestartTest {
                 "import hudson.model.Result\n" +
                 "import jenkins.model.CauseOfInterruption\n" +
                 // This runs during CpsFlowExecution.parseScript which runs during CpsFlowExecution.start.
-                "@ASTTest(value={ Executor.currentExecutor().interrupt(Result.ABORTED, new CauseOfInterruption.UserInterruption('unknown')) }) _\n", false));
+                "@ASTTest(value={\n" +
+                "  def cause = new CauseOfInterruption.UserInterruption('unknown')\n" +
+                "  Executor.currentExecutor().interrupt(Result.ABORTED, cause)\n" +
+                "}) _\n", false));
             WorkflowRun b = r.buildAndAssertStatus(Result.ABORTED, p);
             r.assertLogContains("Aborted by unknown", b);
         });


### PR DESCRIPTION
See [JENKINS-46961](https://issues.jenkins-ci.org/browse/JENKINS-46961) and https://github.com/jenkinsci/workflow-cps-plugin/pull/374.

Pipeline builds that are interrupted via `Executor.interrupt` while the build is still starting (i.e. inside of `CpsFlowExecution.start`) are not persisted correctly and so they resume after a Jenkins restart. When they resume they are too broken to resume correctly and so they exist in a zombie-like state where they aren't doing anything and cannot be stopped normally. I think this happens because the thread's interrupt status has not been cleared when `WorkflowRun.run` catches an exception thrown from `CpsFlowExecution.start` and so any file system operations, such as those needed to save `build.xml` and indicate that the build has completed, automatically fail with a `ClosedByInterruptException` or similar.

This PR fixes the issue by clearing the interrupt status of the thread if an exception is caught in `WorkflowRun.run` so that file system operations complete normally. It also makes sure that the causes of interruption, if any, are printed to the build log, and that the correct build result is reported. https://github.com/jenkinsci/workflow-cps-plugin/pull/374 is needed for interruptions during startup to be detected correctly in some cases.

I have not been able to come up with a test case that fully reproduces the reported issues. The test cases in this PR do not actually resume after the restart, but they do return true from things like `WorkflowRun.isBuilding` and `WorkflowRun.isLogUpdated`, so I think they are still representative of the problem users are reporting.