### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    reviewers:
+      - "dwnusbaum"
+    schedule:
+      interval: "daily"

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.1</version>
+        <version>4.11</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.176.x</artifactId>
-                <version>9</version>
+                <version>13</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.83</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,7 +122,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR updates the parent POM and BOM and sets up daily Dependabot updates. We are using https://github.com/jenkinsci/bom for all plugin dependencies here, so I think Dependabot will only files PRs for the parent POM and BOM, which should keep things from being too noisy.