### PR TITLE
Add node indicator to build overview page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
@@ -39,6 +39,9 @@
                     <j:if test="${!it.building}">
                         ${%Took} <a href="${rootURL}/${it.parent.url}buildTimeTrend">${it.durationString}</a>
                     </j:if>
+                    <j:if test="${it.builtOnStr != null and it.builtOnStr != ''}">
+                        ${%on} <t:node value="${it.builtOn}" valueStr="${it.builtOnStr}"/>
+                    </j:if>
                 </div>
             </div>
             <!-- TODO this calls t:buildProgressBar, which after a restart shows the wrong start time (and expected duration) for the build, since Executor.startTime is meaningless for an AfterRestartTask -->


### PR DESCRIPTION
Pipeline builds currently do not show the node they were built on in the build overview page:
![image](https://user-images.githubusercontent.com/14999635/95922993-c8426180-0db4-11eb-8196-5ff72d6555f1.png)

In case only a single node is used during a pipeline build, it should be displayed the same way as in a freestyle build:
![image](https://user-images.githubusercontent.com/14999635/95923280-72ba8480-0db5-11eb-9fbd-1a65e8ef9d17.png)

Reading nodes from WorkspaceActions seemed the most sensible to me, as it works for old builds that have already been completed and requires no modifications to other pipeline plugins. The jelly implementation is very similar to [Jenkins core](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/AbstractBuild/index.jelly#L44), so it does not need additional localization or components. This does limit the feature to builds that only use a single node, but I would guess that that is the most common case. 
Perhaps a text saying 'on multiple nodes' might be an alternative for builds that used multiple nodes.

I'd be happy to hear your feedback on this! Since I'm contributing this as part of Hacktoberfest, I'd appreciate it if you could tag this PR with hacktoberfest-accepted as well.