### PR TITLE
JENKINS-65033 Run summary - tables to divs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,17 +64,18 @@
     <properties>
         <revision>2.41</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
+        <hpi.compatibleSinceVersion>2.26</hpi.compatibleSinceVersion>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>16</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>25</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -184,13 +185,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                 <reuseForks>false</reuseForks> <!-- TODO reuse seems to cause problems in memory tests -->
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <compatibleSinceVersion>2.26</compatibleSinceVersion>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
-                <version>25</version>
+                <version>26</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
@@ -3,7 +3,7 @@
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (c) 2013-2014, CloudBees, Inc.
+  ~ Copyright (c) 2013-2021, CloudBees, Inc., Tim Jacomb
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,36 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:i="jelly:fmt"
+         xmlns:local="local" xmlns:d="jelly:define">
+    <d:taglib uri="local">
+        <d:tag name="container">
+            <j:choose>
+                <j:when test="${divBasedRunLayout}">
+                    <div>
+                        <d:invokeBody/>
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <table style="margin-top: 1em; margin-left:1em;">
+                        <d:invokeBody/>
+                    </table>
+                </j:otherwise>
+            </j:choose>
+        </d:tag>
+        <d:tag name="blockWrapper">
+            <j:choose>
+                <j:when test="${divBasedRunLayout}">
+                    <div style="margin-top: 1em;">
+                        <d:invokeBody/>
+                    </div>
+                </j:when>
+                <j:otherwise>
+                    <d:invokeBody/>
+                </j:otherwise>
+            </j:choose>
+        </d:tag>
+    </d:taglib>
     <l:layout title="${it.fullDisplayName}">
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
@@ -49,7 +78,7 @@
             <div>
                 <t:editableDescription permission="${it.UPDATE}"/>
             </div>
-            <table style="margin-top: 1em; margin-left:1em;">
+            <local:container>
                 <t:artifactList build="${it}" caption="${%Build Artifacts}" permission="${it.ARTIFACTS}"/>
                 <j:set var="changeSets" value="${it.changeSets}"/>
                 <j:if test="${!changeSets.isEmpty()}">
@@ -60,9 +89,11 @@
                     </t:summary>
                 </j:if>
                 <j:forEach var="a" items="${it.allActions}">
-                    <st:include page="summary.jelly" from="${a}" optional="true" it="${a}"/>
+                    <local:blockWrapper>
+                        <st:include page="summary.jelly" from="${a}" optional="true" it="${a}"/>
+                    </local:blockWrapper>
                 </j:forEach>
-            </table>
+            </local:container>
             <!-- TODO no upstream/downstream builds; DependencyGraph uses AP, for no obvious reason -->
         </l:main-panel>
     </l:layout>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

See [JENKINS-65033](https://issues.jenkins.io/browse/JENKINS-65033).

Changes the Run summary page to use divs for layout if running on a version of core that sets the `divBasedRunLayout` variable (https://github.com/jenkinsci/jenkins/pull/5351)

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes

Relates to https://github.com/jenkinsci/jenkins/pull/5351, uses feature detection to work together with it, does nothing without it but can be merged and released independently

- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Tested with the Jenkinsfile in https://github.com/timja-org/codingstyle

![image](https://user-images.githubusercontent.com/21194782/110702808-e937a300-81ea-11eb-9bd8-dc7e4a65ef32.png)


cc @car-roll @dwnusbaum @bitwiseman @fqueiruga 