### PR TITLE
Ensure pipeline error messages are printed before RunListener.fireCompleted()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -607,8 +607,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 // Never even made it to running, either failed when fresh-started or resumed -- otherwise getListener would have run
                 LOGGER.log(Level.WARNING, this + " failed to start", t);
             } else {
-                RunListener.fireCompleted(WorkflowRun.this, myListener);
-                fireCompleted();
                 if (t instanceof AbortException) {
                     myListener.error(t.getMessage());
                 } else if (t instanceof FlowInterruptedException) {
@@ -616,6 +614,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 } else if (t != null) {
                     Functions.printStackTrace(t, myListener.getLogger());
                 }
+                RunListener.fireCompleted(WorkflowRun.this, myListener);
+                fireCompleted();
                 myListener.finished(getResult());
                 if (myListener instanceof AutoCloseable) {
                     try {


### PR DESCRIPTION
By not writing stack traces to the console log before executing
RunListener.fireCompleted() we cannot carry out error analysis
from upstream jobs before the downstream builds are released.

This brings issues with other Extensions like the Build Failure Analyzer.

It's reasonable that any important error messages concerning the flow
execution is printed before the Run is completed.

Example:
https://issues.jenkins.io/browse/JENKINS-42755

In the linked issue, the fix was erroneously "fixed" in BFA, with bad
side effects, like downstream builds being BFA-analyzed *after* the
waiting upstream build is completed and the possibility to correctly
aggregate BFA findings in upstream jobs are gone.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
