### PR TITLE
Improve durability of `SURVIVABLE_NONATOMIC` while retaining the skipping of `fsync(2)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,19 +64,20 @@
     <properties>
         <revision>2.42</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.300-rc31329.23a941f5b44f</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5599 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <hpi.compatibleSinceVersion>2.26</hpi.compatibleSinceVersion>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <workflow-support-plugin.version>3.9-rc775.8f378c2fa520</workflow-support-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/120 -->
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>831.v9814430e6383</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>887.vae9c8ac09ff7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -90,10 +91,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <version>2.47-rc1093.d73752dcf969</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/163 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
+            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -119,6 +122,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
+            <version>${workflow-support-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1193,17 +1193,19 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         XmlFile file = new XmlFile(XSTREAM,loc);
 
         boolean isAtomic = true;
+        boolean isForce = true;
         FlowExecution fetchedExecution = this.execution;  // Avoid triggering loading unless we need to
         if (fetchedExecution != null) {
             FlowDurabilityHint hint = fetchedExecution.getDurabilityHint();
             isAtomic = hint.isAtomicWrite();
+            isForce = hint.isForce();
         }
 
         boolean completeAsynchronousExecution = false;
         try {
             synchronized (this) {
                 completeAsynchronousExecution = Boolean.TRUE.equals(completed);
-                PipelineIOUtils.writeByXStream(this, loc, XSTREAM2, isAtomic);
+                PipelineIOUtils.writeByXStream(this, loc, XSTREAM2, isAtomic, isForce);
                 SaveableListener.fireOnChange(this, file);
             }
         } finally {


### PR DESCRIPTION
Not yet ready for review. Filing just to get an incremental build.

See [JENKINS-66001](https://issues.jenkins.io/browse/JENKINS-66001). Downstream of jenkinsci/jenkins#5599, jenkinsci/workflow-api-plugin#163, and jenkinsci/workflow-support-plugin#120. Part 5 of a 5-part series to make Pipeline's `SURVIVABLE_NONATOMIC` mode behave [as advertised in the documentation](https://www.jenkins.io/doc/book/pipeline/scaling-pipeline/#what-am-i-giving-up-with-this-durability-setting-trade-off).