### PR TITLE
[JENKINS-43353] Option to disable concurrent builds by aborting previous ones

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -312,7 +312,9 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
 
     @Exported
     @Override public boolean isConcurrentBuild() {
-        return getProperty(DisableConcurrentBuildsJobProperty.class) == null;
+        DisableConcurrentBuildsJobProperty p = getProperty(DisableConcurrentBuildsJobProperty.class);
+        // For purposes of the Jenkins queue, abortPrevious mode means that the new build must start concurrently with the old at least temporarily.
+        return p == null || p != null && p.isAbortPrevious();
     }
 
     @Exported

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -113,6 +113,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowEndNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
 import org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote;
+import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty;
 import org.jenkinsci.plugins.workflow.log.LogStorage;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException;
@@ -333,6 +334,17 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             newExecution.start();  // We should probably have the promise set before beginning, no?
             FlowExecutionListener.fireRunning(newExecution);
 
+            DisableConcurrentBuildsJobProperty dcb = getParent().getProperty(DisableConcurrentBuildsJobProperty.class);
+            if (dcb != null && dcb.isAbortPrevious()) {
+                WorkflowRun prev = getPreviousBuildInProgress();
+                if (prev != null) {
+                    Executor e = prev.getExecutor();
+                    if (e != null) {
+                        e.interrupt(Result.NOT_BUILT, new DisableConcurrentBuildsJobProperty.CancelledCause(this));
+                    }
+                }
+                // Not bothering to look for other older builds in progress, since once we turn this on, going forward there should be at most one.
+            }
         } catch (Throwable x) {
             execution = null; // ensures isInProgress returns false
             executionLoaded = true;

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/CancelledCause/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/CancelledCause/summary.jelly
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2021 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <j:set var="newerBuild" value="${it.newerBuild}"/>
+    <j:choose>
+        <j:when test="${newerBuild != null}">
+            Superseded by <a class="model-link inside" href="${rootURL}/${newerBuild.url}/">${newerBuild.displayName}</a>
+        </j:when>
+        <j:otherwise>
+            <j:out value="${it.shortDescription}"/>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/config-details.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/config-details.jelly
@@ -26,4 +26,8 @@
   -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" />
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="abortPrevious">
+        <f:checkbox title="Abort previous builds"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/help-abortPrevious.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobProperty/help-abortPrevious.html
@@ -1,0 +1,6 @@
+<div>
+    By default, disabling concurrent builds means that new builds will queue up and wait for a running build to complete.
+    With this option, scheduling a new build immediately aborts any running build.
+    This is handy for example if you have an expensive pull request testing procedure
+    and do not wish to waste any time completing tests on an outdated commit.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobPropertyTest.java
@@ -25,7 +25,14 @@
  */
 package org.jenkinsci.plugins.workflow.job.properties;
 
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.model.InterruptedBuildAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import static org.junit.Assert.assertEquals;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -79,5 +86,60 @@ public class DisableConcurrentBuildsJobPropertyTest {
 
         WorkflowJob roundTripDisabled = r.configRoundtrip(disabledCase);
         assertFalse(roundTripDisabled.isConcurrentBuild());
+
+        DisableConcurrentBuildsJobProperty prop = roundTripDisabled.getProperty(DisableConcurrentBuildsJobProperty.class);
+        assertNotNull(prop);
+        assertFalse(prop.isAbortPrevious());
+        prop.setAbortPrevious(true);
+        roundTripDisabled = r.configRoundtrip(roundTripDisabled);
+        assertTrue(roundTripDisabled.isConcurrentBuild()); // see comment there
+        prop = roundTripDisabled.getProperty(DisableConcurrentBuildsJobProperty.class);
+        assertNotNull(prop);
+        assertTrue(prop.isAbortPrevious());
     }
+
+    @Issue("JENKINS-43353")
+    @Test public void abortPrevious() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("semaphore 'run'", true));
+
+        // Control case: concurrent builds allowed.
+        assertTrue(p.isConcurrentBuild());
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("run/1", b1);
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("run/2", b2);
+        SemaphoreStep.success("run/1", null);
+        SemaphoreStep.success("run/2", null);
+        r.waitForCompletion(b1);
+        r.waitForCompletion(b2);
+
+        // Control case: simple disable concurrent.
+        p.setConcurrentBuild(false);
+        assertFalse(p.isConcurrentBuild());
+        WorkflowRun b3 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("run/3", b3);
+        SemaphoreStep.success("run/4", null);
+        QueueTaskFuture<WorkflowRun> b4f = p.scheduleBuild2(0);
+        Thread.sleep(1000); // TODO is there a cleaner way for the queue to finish processing?
+        assertFalse(b4f.getStartCondition().isDone());
+        SemaphoreStep.success("run/3", null);
+        r.waitForCompletion(b4f.waitForStart());
+        r.waitForCompletion(b3);
+
+        // Test case: abort previous.
+        p.getProperty(DisableConcurrentBuildsJobProperty.class).setAbortPrevious(true);
+        assertTrue(p.isConcurrentBuild()); // see comment there
+        WorkflowRun b5 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("run/5", b5);
+        WorkflowRun b6 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("run/6", b6);
+        r.assertBuildStatus(Result.NOT_BUILT, r.waitForCompletion(b5));
+        InterruptedBuildAction iba = b5.getAction(InterruptedBuildAction.class);
+        assertNotNull(iba);
+        assertEquals(1, iba.getCauses().size());
+        assertEquals(DisableConcurrentBuildsJobProperty.CancelledCause.class, iba.getCauses().get(0).getClass());
+        assertEquals(b6, ((DisableConcurrentBuildsJobProperty.CancelledCause) iba.getCauses().get(0)).getNewerBuild());
+    }
+
 }


### PR DESCRIPTION
[JENKINS-43353](https://issues.jenkins.io/browse/JENKINS-43353), more straightforward and efficient than using the previous hack

```groovy
def buildNumber = BUILD_NUMBER as int; if (buildNumber > 1) milestone(buildNumber - 1); milestone(buildNumber)
```

Can be configured via GUI (for standalone Pipelines) or as code

```groovy
properties([disableConcurrentBuilds(abortPrevious: true)])
```
