### PR TITLE
Move content of `buildCaption` text into single line.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
@@ -32,9 +32,7 @@ THE SOFTWARE.
   <l:layout title="${it.fullDisplayName} Console" norefresh="true">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <t:buildCaption>
-        ${%Console Output}
-      </t:buildCaption>
+      <t:buildCaption>${%Console Output}</t:buildCaption>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
       <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />
@@ -54,7 +52,7 @@ THE SOFTWARE.
         <j:when test="${it.isLogUpdated()}">
           <pre id="out" class="console-output" />
             <div id="spinner">
-              <img src="${imagesURL}/spinner.gif" alt="" /> 
+              <img src="${imagesURL}/spinner.gif" alt="" />
             </div>
           <t:progressiveText href="logText/progressiveHtml" idref="out" spinner="spinner"
                startOffset="${offset}" onFinishEvent="jenkins:consoleFinished"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/index.jelly
@@ -71,10 +71,7 @@
                 </div>
             </div>
             <!-- TODO this calls t:buildProgressBar, which after a restart shows the wrong start time (and expected duration) for the build, since Executor.startTime is meaningless for an AfterRestartTask -->
-            <t:buildCaption>
-                ${%Build} ${it.displayName}
-                (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)
-            </t:buildCaption>
+            <t:buildCaption>${%Build} ${it.displayName} (<i:formatDate value="${it.timestamp.time}" type="both" dateStyle="medium" timeStyle="medium"/>)</t:buildCaption>
             <div>
                 <t:editableDescription permission="${it.UPDATE}"/>
             </div>


### PR DESCRIPTION
Since the text is copied into an `<h1>` tag, linebreaks will create
a wrong gap between the build status icon and the text.

Followup to https://github.com/jenkinsci/jenkins/pull/5507.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
