### PR TITLE
Skip tests using `@ASTTest` which fail when `LibraryDecorator` is present

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -41,6 +41,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowStartNode;
 import org.jenkinsci.plugins.workflow.job.properties.DurabilityHintJobProperty;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +54,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.List;
 import java.util.Set;
+import static org.hamcrest.Matchers.nullValue;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -216,6 +218,7 @@ public class WorkflowRunRestartTest {
     @Issue("JENKINS-46961")
     @Test public void interruptedWhileStartingMaxSurvivability() throws Exception {
         story.then(r -> {
+            Assume.assumeThat("import from LibraryDecorator will not resolve in PCT", r.jenkins.pluginManager.getPlugin("workflow-cps-global-lib"), nullValue());
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.setDefinition(new CpsFlowDefinition(
                 "import groovy.transform.*\n" +
@@ -240,6 +243,7 @@ public class WorkflowRunRestartTest {
     @Issue("JENKINS-46961")
     @Test public void interruptedWhileStartingPerformanceOptimized() throws Exception {
         story.then(r -> {
+            Assume.assumeThat("import from LibraryDecorator will not resolve in PCT", r.jenkins.pluginManager.getPlugin("workflow-cps-global-lib"), nullValue());
             WorkflowJob p = r.createProject(WorkflowJob.class, "p");
             p.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.PERFORMANCE_OPTIMIZED));
             p.setDefinition(new CpsFlowDefinition(


### PR DESCRIPTION
Amends the tests added in #167 since they fail when you set `jth.jenkins-war.path` to a megawar containing `workflow-cps-global-lib`:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script1.groovy: -1: unable to resolve class org.jenkinsci.plugins.workflow.libs.Library
 @ line -1, column -1.
1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:958)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:554)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:584)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:623)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:594)
	at groovy.lang.GroovyShell$evaluate.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.transform.ASTTestTransformation$1.call(ASTTestTransformation.groovy:112)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:562)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:571)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:523)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:337)
	at …
```

Somehow https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/7947cd4ebdc358122f422dd0510b428655833247/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java#L63 is honored yet https://github.com/jenkinsci/workflow-cps-plugin/blob/32593e08dee8732a52f7eee68d99a4917bc0b5c5/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsGroovyShellFactory.java#L113 is not.

Fixes https://github.com/jenkinsci/bom/issues/611.
