### PR TITLE
Ensure all runs with corrupt execution are marked as failures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -725,9 +725,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     executionLoaded = true;
                     return fetchedExecution;
                 } catch (Exception x) {
-                    if (result == null) {
-                        setResult(Result.FAILURE);
-                    }
+                    setResult(Result.FAILURE);
                     LOGGER.log(Level.WARNING, "Nulling out FlowExecution due to error in build " + this, x);
                     execution = null; // probably too broken to use
                     executionLoaded = true;


### PR DESCRIPTION
Previously, if execution failed to load, the build was only marked as failure if no result had been set. This is quite error prone since several steps might modify the result during the pipeline execution (e.g. junit step). If Jenkins failed hard after such a step, the build  would keep this result after starting up again, giving a false indication that the job had passed.

For example; A build consists of many steps, in one of the steps junit marks the build as unstable but the build continues. The Jenkins master then runs out of diskspace, Jenkins fails to save the pipeline state and Jenkins JVM fails hard. Once Jenkins resumes it will load the job, fail to load execution, mark the build as completed and keep the UNSTABLE result.

There is one corner case where this fix will mark legit completed builds as failures, and that is when the flow execution files become corrupt after the job has finished. However, I argue that this is a far more unlikely situation than that the execution files are corrupt due to writing by Jenkins.

I haven't added any testcase, partially due the lack of existing test which test recovery from bad execution files. But also I can't for the life of me figure out how to make a test case that writes corrupt flow execution files. Suggestions are welcome.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

