### PR TITLE
[JENKINS-68981] Change access level of `WorkflowRun#isInProgress` to `public`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -778,7 +778,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @Exported
-    @Override protected boolean isInProgress() {
+    @Override public boolean isInProgress() {
         if (Boolean.TRUE.equals(completed)) {  // Has a persisted completion state
             return false;
         } else {


### PR DESCRIPTION
Issue: [JENKINS-68981](https://issues.jenkins.io/browse/JENKINS-68981)
Related PR https://github.com/jenkinsci/jenkins/pull/6829

This PR change the access level to public so that it can be changed in Jenkins to

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
