### PR TITLE
Remove java 8 from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: "linux", jdk: "8" ],
-  [ platform: "windows", jdk: "8" ],
+  [ platform: "windows", jdk: "11" ],
   [ platform: "linux", jdk: "11" ]
 ])


### PR DESCRIPTION
This plugins needs to swap to the weekly line temporarily in https://github.com/jenkinsci/workflow-job-plugin/pull/261

Java 8 has been dropped and the build is failing there (and Jan can't update the Jenkinsfile)