### PR TITLE
Deduplicate project page entries

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowJob/main.jelly
@@ -31,9 +31,6 @@
         <!-- TODO display prominentActions -->
         <!-- TODO display any workspace(s) if possible -->
         <t:artifactList caption="${%Last Successful Artifacts}" build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/" permission="${it.lastSuccessfulBuild.ARTIFACTS}"/>
-        <t:summary icon="symbol-changes" href="changes">
-            ${%Recent Changes}
-        </t:summary>
     </table>
     <j:forEach var="a" items="${it.allActions}">
         <st:include page="jobMain.jelly" it="${a}" optional="true" />


### PR DESCRIPTION
Adapting the forthcoming change from https://github.com/jenkinsci/jenkins/pull/6918 to deduplicate items from the project page and the sidepanel.
The change proposed removes the "Recent changes" object, because it's already covered by the sidepanel.