### PR TITLE
Robustness of `NewNodeConsoleNote.annotate`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
@@ -99,8 +99,12 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
 
     @Override
     public ConsoleAnnotator<?> annotate(WorkflowRun context, MarkupText text, int charPos) {
-        StringBuilder startTag = startTagFor(context, id, start, enclosing);
-        text.addMarkup(0, text.length(), startTag.toString(), "</span>");
+        try {
+            StringBuilder startTag = startTagFor(context, id, start, enclosing);
+            text.addMarkup(0, text.length(), startTag.toString(), "</span>");
+        } catch (RuntimeException x) {
+            LOGGER.log(Level.WARNING, null, x);
+        }
         return null;
     }
 


### PR DESCRIPTION
Under some circumstances I have observed an error like

```
java.lang.NullPointerException
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getNode(CpsFlowExecution.java:1194)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.startTagFor(NewNodeConsoleNote.java:119)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.annotate(NewNodeConsoleNote.java:102)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.annotate(NewNodeConsoleNote.java:62)
	at hudson.console.ConsoleAnnotationOutputStream$1.annotate(ConsoleAnnotationOutputStream.java:119)
	at hudson.console.ConsoleAnnotator$ConsoleAnnotatorAggregator.annotate(ConsoleAnnotator.java:108)
	at hudson.console.ConsoleAnnotationOutputStream.eol(ConsoleAnnotationOutputStream.java:147)
	at hudson.console.LineTransformationOutputStream.eol(LineTransformationOutputStream.java:61)
	at hudson.console.LineTransformationOutputStream.write(LineTransformationOutputStream.java:57)
	at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:87)
	at org.jenkinsci.plugins.workflow.log.FileLogStorage$1$1.write(FileLogStorage.java:242)
	at java.base/java.io.FilterOutputStream.write(FilterOutputStream.java:137)
	at org.apache.commons.io.output.ProxyOutputStream.write(ProxyOutputStream.java:92)
	at org.kohsuke.stapler.framework.io.LargeText$HeadMark.moveTo(LargeText.java:329)
	at org.kohsuke.stapler.framework.io.LargeText.writeLogTo(LargeText.java:244)
	at hudson.console.AnnotatedLargeText.writeRawLogTo(AnnotatedLargeText.java:173)
	at org.jenkinsci.plugins.workflow.log.FileLogStorage$1.writeHtmlTo(FileLogStorage.java:207)
	at hudson.console.AnnotatedLargeText.writeLogTo(AnnotatedLargeText.java:152)
	at org.kohsuke.stapler.framework.io.LargeText.doProgressText(LargeText.java:279)
	at hudson.console.AnnotatedLargeText.doProgressiveHtml(AnnotatedLargeText.java:95)
```

This breaks display of the build log completely. Regardless of root cause, problems in `NewNodeConsoleNote` should be treated as nonfatal.
