### PR TITLE
[JENKINS-69915] do not use inline js blocks (csp)

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/index.jelly
@@ -30,9 +30,7 @@ THE SOFTWARE.
         <l:main-panel>
             <st:include it="${it.flowGraph}" page="ajax"/>
             <j:if test="${it.run.building}">
-              <script>
-                refreshPart('nodeGraph','./flowGraph/ajax')
-              </script>
+                <st:adjunct includes="org.jenkinsci.plugins.workflow.job.views.FlowGraphTableAction.refresh"/>
             </j:if>
         </l:main-panel>
     </l:layout>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/refresh.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/views/FlowGraphTableAction/refresh.js
@@ -1,0 +1,1 @@
+refreshPart('nodeGraph','./flowGraph/ajax');


### PR DESCRIPTION
Hello, HacktoberFest is here ([Content Security Policy: smooth introduction Topic](https://issues.jenkins.io/browse/JENKINS-60865))

See [JENKINS-69915](https://issues.jenkins.io/browse/JENKINS-69915).

[Content-Security-Policy Compatibility documentation](https://www.jenkins.io/doc/developer/security/csp/#inline-event-handlers)

Manual testing recoding:

https://user-images.githubusercontent.com/47667812/198619385-3ec6f651-883c-49a8-a9fe-f0b401eb53d6.mov

