### PR TITLE
Drop dependency on Commons Lang 3

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -73,7 +73,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matcher;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;


### PR DESCRIPTION
Commons Lang 2 is safe to depend on because it is provided by Jenkins core, but Commons Lang 3 is provided more or less in error by the test harness as explained in https://github.com/jenkinsci/jenkins-test-harness/issues/550. Safer in the long term to depend on Commons Lang 2 in case https://github.com/jenkinsci/jenkins-test-harness/issues/550 ever gets fixed.