### PR TITLE
Add `pipeline-groovy-lib` to test classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>workflow-support</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>pipeline-groovy-lib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Noticed while testing https://github.com/jenkinsci/maven-hpi-plugin/pull/461 in https://github.com/jenkinsci/plugin-compat-tester/pull/505 and https://github.com/jenkinsci/bom/pull/1908. I have not come to a root cause yet, but this PR chases the problem away (just like https://github.com/jenkinsci/matrix-auth-plugin/pull/133). Since adding a dependency to the test classpath is pretty harmless, I think it is worth doing this in the meantime to be able to make progress on the abovementioned PRs.