### PR TITLE
Improved `WorkflowRun.finish` timing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,5 +185,17 @@
             <artifactId>timestamper</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -752,6 +752,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     execution = null; // probably too broken to use
                     executionLoaded = true;
                     saveWithoutFailing(true); // Ensure we do not try to load again
+                    completeAsynchronousExecution();
                     return null;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -671,8 +671,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
             onEndBuilding();
         } finally {  // Ensure this is ALWAYS removed from FlowExecutionList
             FlowExecutionList.get().unregister(new Owner(this));
+            completeAsynchronousExecution();
         }
-        completeAsynchronousExecution();
     }
 
     private void fireCompleted(){

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -118,7 +118,7 @@ public class WorkflowRunRestartTest {
 
     @Issue({"JENKINS-45585", "JENKINS-50784"})  // Verifies execution lazy-load
     @Test public void lazyLoadExecution() {
-        story.thenWithHardShutdown(r -> {
+        story.then(r -> {
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
             p.addProperty(new DurabilityHintJobProperty(FlowDurabilityHint.MAX_SURVIVABILITY));
             p.setDefinition(new CpsFlowDefinition("echo 'dosomething'", true));


### PR DESCRIPTION
I found that `BulkChange` from `CpsFlowExecution.notifyListeners` caused `WorkflowRun.completed` to be `false` in `build.xml` at the moment `RunListener.onFinalized` is called. Was noted in 18d78f305a4526af9cdf3a7b68eb9caf97c7cfbc in #27.