### PR TITLE
Write NewNodeConsoleNote to per-step logs instead of overall log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
+            <version>1236.vb_763772ecd87</version> <!-- TODO: https://github.com/jenkinsci/workflow-api-plugin/pull/296 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
@@ -60,7 +60,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @see LogStorage#startStep
  */
 @Restricted(NoExternalUse.class)
-public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
+public class NewNodeConsoleNote extends ConsoleNote {
 
     private static final Logger LOGGER = Logger.getLogger(NewNodeConsoleNote.class.getName());
 
@@ -98,7 +98,7 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
     }
 
     @Override
-    public ConsoleAnnotator<?> annotate(WorkflowRun context, MarkupText text, int charPos) {
+    public ConsoleAnnotator<?> annotate(Object context, MarkupText text, int charPos) {
         try {
             StringBuilder startTag = startTagFor(context, id, start, enclosing);
             text.addMarkup(0, text.length(), startTag.toString(), "</span>");
@@ -109,7 +109,7 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
     }
 
     @Restricted(NoExternalUse.class)
-    public static StringBuilder startTagFor(@NonNull WorkflowRun context, @NonNull String id, @CheckForNull String start, @CheckForNull String enclosing) {
+    public static StringBuilder startTagFor(@NonNull Object context, @NonNull String id, @CheckForNull String start, @CheckForNull String enclosing) {
         StringBuilder startTag = new StringBuilder("<span class=\"pipeline-new-node\" nodeId=\"").append(id);
         if (start != null) {
             startTag.append("\" startId=\"").append(start);
@@ -117,7 +117,12 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
         if (enclosing != null) {
             startTag.append("\" enclosingId=\"").append(enclosing);
         }
-        FlowExecution execution = context.getExecution();
+        FlowExecution execution = null;
+        if (context instanceof WorkflowRun) {
+            execution = ((WorkflowRun) context).getExecution();
+        } else if (context instanceof FlowNode) {
+            execution = ((FlowNode) context).getExecution();
+        }
         if (execution != null) {
             try {
                 FlowNode node = execution.getNode(id);

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/console/DefaultLogStorageTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/console/DefaultLogStorageTest.java
@@ -99,7 +99,7 @@ public class DefaultLogStorageTest {
         assertLogContains(page, hudson.model.Messages.Cause_UserIdCause_ShortDescription(alice.getDisplayName()), alice.getUrl());
         assertLogContains(page, "Running inside " + b.getDisplayName(), b.getUrl());
         assertThat(page.getWebResponse().getContentAsString().replace("\r\n", "\n"),
-            containsString("<span class=\"pipeline-new-node\" nodeId=\"3\" enclosingId=\"2\">[Pipeline] hyperlink\n</span><span class=\"pipeline-node-3\">Running inside <a href="));
+            containsString("<span class=\"pipeline-node-3\"><span class=\"pipeline-new-node\" nodeId=\"3\" enclosingId=\"2\">[Pipeline] hyperlink\n</span>Running inside <a href="));
         DepthFirstScanner scanner = new DepthFirstScanner();
         scanner.setup(b.getExecution().getCurrentHeads());
         List<FlowNode> nodes = Lists.newArrayList(scanner.filter(FlowScanningUtils.hasActionPredicate(LogAction.class)));
@@ -187,7 +187,8 @@ public class DefaultLogStorageTest {
         assertNotNull(la);
         baos = new ByteArrayOutputStream();
         la.getLogText().writeRawLogTo(0, baos);
-        assertThat(baos.toString(), not(containsString("Pipeline")));
+        assertThat(baos.toString(), not(containsString("[Pipeline] Start of Pipeline")));
+        assertThat(baos.toString(), containsString("[Pipeline] echo"));
         // Whole-build:
         sw = new StringWriter();
         start = System.nanoTime();
@@ -226,7 +227,7 @@ public class DefaultLogStorageTest {
         start = System.nanoTime();
         length = la.getLogText().length();
         System.out.printf("Took %dms to compute length of one short node%n", (System.nanoTime() - start) / 1000 / 1000);
-        assertThat(length, lessThan(50L));
+        assertThat(length, lessThan(350L));
     }
 
     @Ignore("Currently not asserting anything, just here for interactive evaluation.")


### PR DESCRIPTION
This is currently just a prototype I am using to investigate some things. Requires https://github.com/jenkinsci/workflow-api-plugin/pull/296 to fix a test that happens to trigger that bug with this change.

I am working on a (proprietary) Pipeline log viewer that allows users to view logs for an entire stage or branch, by combining the per-step logs for all the steps in the stage/branch. This works fine, but there are a few issues:
* You lose the `[Pipeline] <step>` lines from `NewNodeConsoleNote` that give you context about what steps are running, which can be confusing if the stage/branch has a lot of steps.
    * There is no supported way to include only the relevant step announcements using public APIs today, you have to either include or exclude lines from the overall log.
* It is difficult to correctly identify where to put context markers indicating when log output changes from one branch to another (as in the left gutter in the classic console). Given two `[Pipeline] <step>` lines in a row, there is no exact way to mark their context.
* It is very awkward to try to identify "meaningful" lines from the overall log, e.g. Jenkins restarting, exceptions at the end of a build, etc.

Emitting the `NewNodeConsoleNote` lines to the per-step logs instead allows all of these issues to be addressed using public APIs. I think it could be useful to the classic console view and other Pipeline log visualizations as well.

Of course there are some drawbacks:
* Visualizations that only show logs for a single step will show at least 1 new log line, i.e. `[Pipeline] <step name>`, which is at best useless for these visualizations since they already indicate what step is selected in some other way.
* Various changes would need to be made to preserve the show/hide behavior in the classic console view.
* I would not be surprised if this breaks tests in various plugins, but I will check at least all BOM plugins if I decide to pursue this change further.
* Probably some other things I haven't thought of.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
