### PR TITLE
Fix show/hide functionality in classic console view

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -111,13 +111,13 @@ function showHidePipelineSection(link) {
             var oid = ids[i]
             if (oid != id && encloses(id, oid, starts, enclosings)) {
                 showHide(oid, display)
-                var headers = document.querySelectorAll('.pipeline-new-node[nodeId=' + oid + ']');
+                var headers = document.querySelectorAll('.pipeline-new-node[nodeId=\"' + oid + '\"]');
                 for (var j = 0; j < headers.length; j++) {
                     headers[j].style.display = display;
                 }
                 if (display === 'inline') {
                     // Mark all children as shown. TODO would be nicer to leave them collapsed if they were before, but this gets complicated.
-                    var links = document.querySelectorAll('.pipeline-new-node[nodeId=' + oid + '] span a');
+                    var links = document.querySelectorAll('.pipeline-new-node[nodeId=\"' + oid + '\"] span a');
                     for (var j = 0; j < links.length; j++) {
                         links[j].textContent = 'hide';
                         links[j].parentNode.className = 'pipeline-show-hide';


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-job-plugin/pull/350 broke the show/hide functionality for block-scope steps in the classic log view. With that change, you get error messages like this if you try to show/hide a block-scope step:

> Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': '.pipeline-new-node[nodeId=3]' is not a valid selector.


### Testing done

I tested manually against https://github.com/jenkinsci/workflow-job-plugin/releases/tag/1308.v58d48a_763b_31 to confirm that show/hide worked before PR 350, against https://github.com/jenkinsci/workflow-job-plugin/releases/tag/1316.vd2290d3341a_f to confirm that show/hide did not work with 350, and against this PR to confirm that show/hide worked again.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
