### PR TITLE
Avoid stack trace from `NewNodeConsoleNote` for a corrupt build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
@@ -104,7 +104,7 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
             StringBuilder startTag = startTagFor(context, id, start, enclosing);
             text.addMarkup(0, text.length(), startTag.toString(), "</span>");
         } catch (RuntimeException x) {
-            LOGGER.log(Level.WARNING, null, x);
+            LOGGER.log(Level.WARNING, "problem in " + context, x);
         }
         return null;
     }
@@ -131,7 +131,7 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
                     }
                 }
             } catch (IOException x) {
-                Logger.getLogger(NewNodeConsoleNote.class.getName()).log(Level.WARNING, null, x);
+                LOGGER.log(Level.FINE, "unloadable " + context, x);
             }
         }
         startTag.append("\">");

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote.java
@@ -131,7 +131,7 @@ public class NewNodeConsoleNote extends ConsoleNote<WorkflowRun> {
                     }
                 }
             } catch (IOException x) {
-                LOGGER.log(Level.FINE, "unloadable " + context, x);
+                LOGGER.log(Level.FINE, x, () -> "unloadable " + context);
             }
         }
         startTag.append("\">");


### PR DESCRIPTION
Noticed a large number of repeated stack traces in the system log like

```
WARNING org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote startTagFor
java.io.IOException: storage not yet loaded
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getNode(CpsFlowExecution.java:1216)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.startTagFor(NewNodeConsoleNote.java:123)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.annotate(NewNodeConsoleNote.java:103)
	at org.jenkinsci.plugins.workflow.job.console.NewNodeConsoleNote.annotate(NewNodeConsoleNote.java:62)
	at hudson.console.ConsoleAnnotationOutputStream$1.annotate(ConsoleAnnotationOutputStream.java:119)
	at hudson.console.ConsoleAnnotator$ConsoleAnnotatorAggregator.annotate(ConsoleAnnotator.java:108)
	at hudson.console.ConsoleAnnotationOutputStream.eol(ConsoleAnnotationOutputStream.java:147)
	at …
	at hudson.console.AnnotatedLargeText.doProgressiveHtml(AnnotatedLargeText.java:95)
	at …
```

I _think_ these corresponded to attempts to view the log of a build whose metadata had been corrupted somehow (hard to verify since the error does not mention the build). At any rate, adding the `label` attribute to `span`s is hardly a critical function, so it is not helpful to warn about this, much less with a stack trace. Reducing the log level, and improving the message to mention the build in case anyone looks.
