### PR TITLE
Override `isInQueue` & `getQueueItem` from `WorkflowJob`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -306,6 +306,18 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         save();
     }
 
+    @Exported
+    @Override
+    public boolean isInQueue() {
+        return Jenkins.get().getQueue().contains(this);
+    }
+
+    @Exported
+    @Override
+    public Queue.Item getQueueItem() {
+        return Jenkins.get().getQueue().getItem(this);
+    }
+
     @Override public CauseOfBlockage getCauseOfBlockage() {
         if (!isConcurrentBuild() && isLogUpdated()) {
             WorkflowRun lastBuild = getLastBuild();


### PR DESCRIPTION
Just noticed that these have placeholder implementations (`false` / `null`) in `Job` which are overridden by `AbstractProject` (because it is a `Queue.Task`) and `WorkflowJob` should do the same.