### PR TITLE
Remove `checkAbortPermission` and `hasAbortPermission` overrides from `WorkflowJob`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -382,14 +382,6 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
         return acl;
     }
 
-    @Override public void checkAbortPermission() {
-        checkPermission(CANCEL);
-    }
-
-    @Override public boolean hasAbortPermission() {
-        return hasPermission(CANCEL);
-    }
-
     /**
      * @deprecated Just use {@link #CANCEL}.
      */


### PR DESCRIPTION
Defaulted as of https://github.com/jenkinsci/jenkins/pull/7926.