### PR TITLE
Use symbol for pipeline icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.440.1</jenkins.version>
+        <jenkins.version>2.454</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <hpi.compatibleSinceVersion>2.26</hpi.compatibleSinceVersion>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -722,6 +722,11 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
             return "plugin/workflow-job/images/pipelinejob.svg";
         }
 
+        @Override
+        public String getIconClassName() {
+            return "symbol-pipeline plugin-workflow-job";
+        }
+
         /** TODO JENKINS-20020 can delete this in case {@code f:dropdownDescriptorSelector} defaults to applying {@code h.filterDescriptors} */
         @Restricted(DoNotUse.class) // Jelly
         public Collection<FlowDefinitionDescriptor> getDefinitionDescriptors(WorkflowJob context) {


### PR DESCRIPTION
Follow up to @mawinter69 changes in core (https://github.com/jenkinsci/jenkins/pull/9127). This PR uses the pipeline symbol now that the 'New item' page supports displaying them.

**Before**
<img width="825" alt="image" src="https://github.com/jenkinsci/workflow-job-plugin/assets/43062514/6da7376a-2f80-4150-b541-71ff89e94f48">

**After**
<img width="832" alt="image" src="https://github.com/jenkinsci/workflow-job-plugin/assets/43062514/c0fc3a15-d9a3-41a5-b846-67b9533a6ebf">

### Testing done

* Pipeline symbol displays as expected in the 'New item' page

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
