### PR TITLE
Remove 'Disable project' button usage in test

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowJobTest.java
@@ -116,15 +116,25 @@ public class WorkflowJobTest {
         assertFalse(p.isDisabled());
         assertTrue(p.isBuildable());
         JenkinsRule.WebClient wc = j.createWebClient();
-        j.submit(wc.getPage(p).getHtmlElementById("disable-project"));
-        assertTrue(p.isDisabled());
-        assertFalse(p.isBuildable());
+
+        // Disable the project
         HtmlForm form = wc.getPage(p, "configure").getFormByName("config");
         HtmlCheckBoxInput checkbox = form.getInputByName("enable");
+        assertTrue(checkbox.isChecked());
+        checkbox.setChecked(false);
+        j.submit(form);
+        assertTrue(p.isDisabled());
+        assertFalse(p.isBuildable());
+
+        // Re-enable the project
+        form = wc.getPage(p, "configure").getFormByName("config");
+        checkbox = form.getInputByName("enable");
         assertFalse(checkbox.isChecked());
-        checkbox.setChecked(true);
+        checkbox.setChecked(false);
         j.submit(form);
         assertFalse(p.isDisabled());
+        assertTrue(p.isBuildable());
+
         wc.getPage(new WebRequest(wc.createCrumbedUrl(p.getUrl() + "disable"), HttpMethod.POST));
         assertTrue(p.isDisabled());
         assertNull(p.scheduleBuild2(0));


### PR DESCRIPTION
As mentioned by @basil in https://github.com/jenkinsci/jenkins/pull/9202#issuecomment-2108608654 the removal of the 'Disable project' button breaks the `WorkflowJobTest#disable` test in this plugin. This PR is to address that by removing its usage of that button and instead using/asserting against the toggle on the 'Configure' page.

### Testing done

N/A

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
