### PR TITLE
Add download option to 'Console output', move 'View as plain text' and 'Copy' buttons to app bar

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
@@ -32,7 +32,21 @@ THE SOFTWARE.
   <l:layout title="${it.fullDisplayName} Console" norefresh="true">
     <st:include page="sidepanel.jelly" />
     <l:main-panel>
-      <t:buildCaption>${%Console Output}</t:buildCaption>
+      <j:set var="controls">
+        <a class="jenkins-button" href="consoleText" download="${it.displayName}.txt">
+          <l:icon src="symbol-download" />
+          ${%Download}
+        </a>
+        <l:copyButton ref="out" label="${%Copy}" />
+        <a class="jenkins-button" href="consoleText">
+          ${%View as plain text}
+        </a>
+      </j:set>
+
+      <t:buildCaption controls="${controls}">
+        ${%Console Output}
+      </t:buildCaption>
+
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />
       <!-- Show at most last 150KB (can override with system property) unless consoleFull is set -->
       <j:set var="offset" value="${empty(consoleFull) ? it.logText.length()-threshold*1024 : 0}" />

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/console.jelly
@@ -83,7 +83,7 @@ THE SOFTWARE.
               <j:out value="${it.flowGraphDataAsHtml}"/>
             </div>
           </j:if>
-          <pre class="console-output">
+          <pre class="console-output" id="out">
             <st:getOutput var="output" />
             <j:whitespace>${it.writeLogTo(offset,output)}</j:whitespace>
           </pre>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/WorkflowRun/sidepanel.jelly
@@ -30,17 +30,7 @@
             <j:set var="buildUrl" value="${h.decompose(request)}"/>
             <l:task icon="symbol-reader-outline plugin-ionicons-api" href="${buildUrl.baseUrl}/" title="${%Status}" contextMenu="false"/>
             <l:task icon="symbol-code-slash-outline plugin-ionicons-api" href="${buildUrl.baseUrl}/changes" title="${%Changes}"/>
-            <j:choose> <!-- TODO <p:console-link/> may not currently be used as it calls getLogFile -->
-                <j:when test="${it.logText.length() > 200000}">
-                    <l:task href="${h.getConsoleUrl(it)}" icon="symbol-terminal-outline plugin-ionicons-api" title="${%Console Output}"/>
-                    <l:task href="${buildUrl.baseUrl}/consoleText" icon="symbol-document-text-outline plugin-ionicons-api" title="${%View as plain text}"/>
-                </j:when>
-                <j:otherwise>
-                    <l:task icon="symbol-terminal-outline plugin-ionicons-api" href="${h.getConsoleUrl(it)}" title="${%Console Output}">
-                        <l:task href="${buildUrl.baseUrl}/consoleText" icon="symbol-document-text-outline plugin-ionicons-api" title="${%View as plain text}"/>
-                    </l:task>
-                </j:otherwise>
-            </j:choose>
+            <l:task href="${h.getConsoleUrl(it)}" icon="symbol-terminal-outline plugin-ionicons-api" title="${%Console Output}"/>
             <!-- Build Information -->
             <j:choose>
                 <j:when test="${h.hasPermission(it,it.UPDATE)}">


### PR DESCRIPTION
<img width="1365" alt="image" src="https://github.com/jenkinsci/workflow-job-plugin/assets/43062514/ae115800-5f5f-490a-93de-486c4d70c910">

Companion to https://github.com/jenkinsci/jenkins/pull/9169. Adds a download option to 'Console output', moves 'View as plain text' and 'Copy' buttons to the app bar. Requires 9169 as a base to show the actions in the app bar, otherwise doesn't show on lower versions of Jenkins - nothing breaks.

Would be good to have the console page be extensible and have this plugin replace just the parts it needs - but out of scope for this PR.

### Testing done

* Copy button works as before
* View as plain text works as before
* Download button downloads the full log

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
