### PR TITLE
fix(delete): [JENKINS-70252] delete WorkflowRun before WorkflowJob

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowJob.java
@@ -663,6 +663,11 @@ public final class WorkflowJob extends Job<WorkflowJob,WorkflowRun> implements L
     @Override protected void performDelete() throws IOException, InterruptedException {
         setDisabled(true);
         Jenkins.get().getQueue().cancel(this);
+
+        for (WorkflowRun workflowRun : getBuilds()) {
+            workflowRun.delete();
+        }
+
         // TODO call SCM.processWorkspaceBeforeDeletion
         super.performDelete();
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

We use the repository scanning feature in the cloudbees-folder-plugin with Multi Branch Pipeline project to delete non-existent branches. When the folder plugin finds out which branch should be deleted, it calls the delete method in the `I` class (`AbstractFolder<I>`), in our case it is WorkflowJob. WorkflowJob only overrides the `performDelete` method, where it disables the job, exits the queue and calls `AbstractItem.performDelete()`. This way WorkflowJob only recursively deletes files under it. There is no logic for deleting artifacts under a WorkflowRun. 

But if you delete only the WorkflowRun (_for example `logRotator` in pipeline options_), it will delete artifacts because the parent class calls `deleteArtifacts` in the `delete` method (*fisrt case in the linked issue*). This is why, for example, artifacts are not deleted from S3 after deleting a branch (*second case in the linked issue*).

I believe it would be correct to update `hudson.model.Job`, where to add logic to remove builds (`hudson.model.Run`) from `getBuilds`. But it was much easier to make changes to the plugin and test it in a production environment.

### Testing done

I really don't know how to test this properly. I just made the changes and tested it in our Jenkins instance. Everything is working as I expected. I will be glad to know how to test this fix.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
