### PR TITLE
[JENKINS-73824][JENKINS-73835] Remove redundant log rotation after changes in core and add regression tests related to deleting Pipeline jobs and builds

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -18,4 +18,4 @@ jobs:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      java-version: 21 # What version of Java to set up for the build.
+      # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- TODO: Waiting for https://github.com/jenkinsci/jenkins/pull/9810 to make it to an LTS line. -->
-        <jenkins.version>2.479-rc35393.97fb_6a_a_25d9b_</jenkins.version>
+        <jenkins.version>2.479-rc35395.f676b_e52239c</jenkins.version>
         <!-- Waiting for a release of https://github.com/jenkinsci/plugin-pom/pull/1004 -->
         <jenkins-test-harness.version>2289.vfd344a_6d1660</jenkins-test-harness.version>
         <hpi-plugin.version>3.58</hpi-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.462.x</artifactId>
-                <version>3221.ve8f7b_fdd149d</version>
+                <artifactId>bom-2.479.x</artifactId>
+                <version>3482.vc10d4f6da_28a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.85</version>
+        <version>4.88</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,7 +63,11 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.454</jenkins.version>
+        <!-- TODO: Waiting for https://github.com/jenkinsci/jenkins/pull/9810 to make it to an LTS line. -->
+        <jenkins.version>2.479-rc35393.97fb_6a_a_25d9b_</jenkins.version>
+        <!-- Waiting for a release of https://github.com/jenkinsci/plugin-pom/pull/1004 -->
+        <jenkins-test-harness.version>2289.vfd344a_6d1660</jenkins-test-harness.version>
+        <hpi-plugin.version>3.58</hpi-plugin.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <hpi.compatibleSinceVersion>2.26</hpi.compatibleSinceVersion>
@@ -73,14 +77,21 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.452.x</artifactId>
-                <version>3023.v02a_987a_b_3ff9</version>
+                <artifactId>bom-weekly</artifactId>
+                <version>3387.v0f2773fa_3200</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <!-- Waiting for a release of https://github.com/jenkinsci/plugin-pom/pull/1004 -->
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>ionicons-api</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -660,13 +660,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 listener = null;
             }
             saveWithoutFailing(true);
-            Timer.get().submit(() -> {
-                try {
-                    getParent().logRotate();
-                } catch (Exception x) {
-                    LOGGER.log(Level.WARNING, "failed to perform log rotation after " + this, x);
-                }
-            });
             onEndBuilding();
         } finally {  // Ensure this is ALWAYS removed from FlowExecutionList
             FlowExecutionList.get().unregister(new Owner(this));

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -713,7 +713,7 @@ public class WorkflowRunTest {
         for (int i = 0; i < buildsToRun; i++) {
             r.waitForCompletion(builds[i]);
         }
-        LOGGER.info("Checking that all build directories are empty ");
+        LOGGER.info("Checking that all build directories are empty");
         for (int i = 0; i < buildsToRun; i++) {
             String[] filesInBuildDir = buildDirs[i].list();
             if (filesInBuildDir == null) {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -28,6 +28,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -58,6 +59,7 @@ import hudson.security.Permission;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
+import hudson.tasks.LogRotator;
 import hudson.util.DescribableList;
 import hudson.util.StreamTaskListener;
 import java.io.File;
@@ -73,6 +75,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
@@ -109,6 +112,7 @@ import org.jvnet.hudson.test.TestExtension;
 import org.xml.sax.SAXException;
 
 public class WorkflowRunTest {
+    private static final Logger LOGGER = Logger.getLogger(WorkflowRunTest.class.getName());
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsRule r = new JenkinsRule();
@@ -520,7 +524,7 @@ public class WorkflowRunTest {
         assertThat(await().until(() -> ExtensionList.lookupSingleton(CheckCompletedFlag.class).buildXml.get(b.getExternalizableId()), notNullValue()),
             containsString("<completed>true</completed>"));
     }
-    @TestExtension public static final class CheckCompletedFlag extends RunListener<WorkflowRun> {
+    @TestExtension("completedFlag") public static final class CheckCompletedFlag extends RunListener<WorkflowRun> {
         final Map<String, String> buildXml = new HashMap<>();
         @Override public void onFinalized(WorkflowRun r) {
             try {
@@ -600,6 +604,20 @@ public class WorkflowRunTest {
         assertPollingBaselines(b3.checkouts(listener), nullValue(), nullValue());
     }
 
+    @SafeVarargs
+    private static void assertPollingBaselines(List<WorkflowRun.SCMCheckout> checkouts, Matcher<Object>... indexedMatchers) {
+        assertThat("Number of checkouts should match number of matchers", checkouts.size(), equalTo(indexedMatchers.length));
+        for (int i = 0; i < checkouts.size(); i++) {
+            assertThat("Unexpected baseline for checkout at index " + i, checkouts.get(i).pollingBaseline, indexedMatchers[i]);
+        }
+    }
+
+    private static String checkoutString(GitSampleRepoRule repo, boolean changelog, boolean polling) {
+        return "    checkout(changelog:" + changelog +", poll:" + polling +
+                ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
+                ", userRemoteConfigs: [[url: $/" + repo.fileUrl() + "/$]]])\n";
+    }
+
     // This test is to ensure that the shortDescription on the CancelCause is escaped properly on summary.jelly
     @Issue("SECURITY-3042")
     @Test public void escapedDisplayNameAfterAbort() throws Exception {
@@ -667,19 +685,42 @@ public class WorkflowRunTest {
 
     }
 
-
-    @SafeVarargs
-    private static void assertPollingBaselines(List<WorkflowRun.SCMCheckout> checkouts, Matcher<Object>... indexedMatchers) {
-        assertThat("Number of checkouts should match number of matchers", checkouts.size(), equalTo(indexedMatchers.length));
-        for (int i = 0; i < checkouts.size(); i++) {
-            assertThat("Unexpected baseline for checkout at index " + i, checkouts.get(i).pollingBaseline, indexedMatchers[i]);
+    @Issue("JENKINS-73835")
+    @Test public void logRotationOnlyProcessesCompletedBuilds() throws Throwable {
+        logging.record(LogRotator.class, Level.FINER);
+        var p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition(
+                "echo params.FOO; semaphore 'wait'", true));
+        p.addProperty(new ParametersDefinitionProperty(List.of(new StringParameterDefinition("FOO"))));
+        // Keep 0 builds, i.e. delete all builds immediately.
+        LogRotator logRotator = new LogRotator(-1, 0, -1, -1);
+        logRotator.setRemoveLastBuild(true);
+        p.setBuildDiscarder(logRotator);
+        int buildsToRun = 10; // Increase this number to reproduce the issue more easily prior to the fix.
+        Run[] builds = new Run[buildsToRun];
+        File[] buildDirs = new File[buildsToRun];
+        // Run a large number of builds that should finish around the same time to check race conditions with log rotation and build completion.
+        for (int i = 0; i < buildsToRun; i++) {
+            var b = p.scheduleBuild2(0, new ParametersAction(List.of(new StringParameterValue("FOO", "b" + i)))).waitForStart();
+            builds[i] = b;
+            buildDirs[i] = b.getRootDir();
+            SemaphoreStep.waitForStart("wait/" + (i+1), b);
         }
-    }
-
-    private static String checkoutString(GitSampleRepoRule repo, boolean changelog, boolean polling) {
-        return "    checkout(changelog:" + changelog +", poll:" + polling +
-                ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
-                ", userRemoteConfigs: [[url: $/" + repo.fileUrl() + "/$]]])\n";
+        for (int i = 0; i < buildsToRun; i++) {
+            SemaphoreStep.success("wait/" + (i+1), null);
+        }
+        LOGGER.info("Waiting for all builds to complete");
+        for (int i = 0; i < buildsToRun; i++) {
+            r.waitForCompletion(builds[i]);
+        }
+        LOGGER.info("Checking that all build directories are empty ");
+        for (int i = 0; i < buildsToRun; i++) {
+            String[] filesInBuildDir = buildDirs[i].list();
+            if (filesInBuildDir == null) {
+                filesInBuildDir = new String[0];
+            }
+            assertThat("Expected " + buildDirs[i] + " to be empty but saw: " + Arrays.toString(filesInBuildDir), filesInBuildDir, emptyArray());
+        }
     }
 
 }


### PR DESCRIPTION
See [JENKINS-73835](https://issues.jenkins.io/browse/JENKINS-73835) and https://github.com/jenkinsci/jenkins/pull/9810. Thematically related to https://github.com/jenkinsci/workflow-job-plugin/pull/468 and https://github.com/jenkinsci/jenkins/pull/9790.

The upstream changes allow us to remove the direct call to `getParent().logRotate()` from `WorkflowRun.finish()` in this PR, and we can add a regression test for log rotation potentially cleaning up Pipeline builds too early.

### Testing done

See new automated test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
