### PR TITLE
`FlowExecution.getOwner` left null after `WorkflowRun.reload`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -553,6 +553,10 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
+        var _execution = execution;
+        if (_execution != null) {
+            _execution.onLoad(new Owner(this));
+        }
     }
 
     @Override protected void onLoad() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -555,9 +555,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
             if (Boolean.TRUE.equals(this.completed)) {
-                var _execution = execution;
-                if (_execution != null) {
-                    _execution.onLoad(new Owner(this));
+                if (execution != null) {
+                    execution.onLoad(new Owner(this));
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -555,7 +555,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
             if (Boolean.TRUE.equals(this.completed)) {
-                if (execution != null) {
+                if (execution != null && executionLoaded) {
                     execution.onLoad(new Owner(this));
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -553,9 +553,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
-        var _execution = execution;
-        if (_execution != null) {
-            _execution.onLoad(new Owner(this));
+        if (Boolean.TRUE.equals(this.completed)) {
+            var _execution = execution;
+            if (_execution != null) {
+                _execution.onLoad(new Owner(this));
+            }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -553,10 +553,12 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
-        if (Boolean.TRUE.equals(this.completed)) {
-            var _execution = execution;
-            if (_execution != null) {
-                _execution.onLoad(new Owner(this));
+        synchronized (getMetadataGuard()) {
+            if (Boolean.TRUE.equals(this.completed)) {
+                var _execution = execution;
+                if (_execution != null) {
+                    _execution.onLoad(new Owner(this));
+                }
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -554,7 +554,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
-            if (Boolean.TRUE.equals(this.completed) && execution != null && executionLoaded) {
+            if (Boolean.TRUE.equals(completed) && execution != null && executionLoaded) {
                 execution.onLoad(new Owner(this));
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -554,8 +554,11 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
-            if (Boolean.TRUE.equals(completed) && execution != null && executionLoaded) {
-                execution.onLoad(new Owner(this));
+            if (Boolean.TRUE.equals(completed) && executionLoaded) {
+                var _execution = execution;
+                if (_execution != null) {
+                    _execution.onLoad(new Owner(this));
+                }
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -554,10 +554,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
-            if (Boolean.TRUE.equals(this.completed)) {
-                if (execution != null && executionLoaded) {
-                    execution.onLoad(new Owner(this));
-                }
+            if (Boolean.TRUE.equals(this.completed) && execution != null && executionLoaded) {
+                execution.onLoad(new Owner(this));
             }
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -620,7 +620,7 @@ public class WorkflowRunTest {
     }
 
     @Test public void reloadOwner() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "reloadOwner");
         p.setDefinition(new CpsFlowDefinition("", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         assertThat("right owner before reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -598,6 +599,15 @@ public class WorkflowRunTest {
         WorkflowRun b3 = r.buildAndAssertSuccess(p);
         //Both have their baselines wiped
         assertPollingBaselines(b3.checkouts(listener), nullValue(), nullValue());
+    }
+
+    @Test public void reloadOwner() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        assertThat("right owner before reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));
+        b.reload();
+        assertThat("right owner after reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));
     }
 
     // This test is to ensure that the shortDescription on the CancelCause is escaped properly on summary.jelly


### PR DESCRIPTION
Would not normally matter I think, but can cause confusing error messages from `CpsFlowExecution` which normally assumes that its `owner` is non-null at almost all times; in particular `toString` then makes no mention of which build is having issues.