### PR TITLE
Stop using deprecated method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1130,7 +1130,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
     @Override public void doConsoleText(StaplerRequest req, StaplerResponse rsp) throws IOException {
         rsp.setContentType("text/plain;charset=UTF-8");
-        try (OutputStream os = rsp.getCompressedOutputStream(req)) {
+        try (OutputStream os = rsp.getOutputStream()) {
             writeLogTo(getLogText()::writeLogTo, os);
         }
     }


### PR DESCRIPTION
As of the current Jenkins core baseline, this method is deprecated and just delegates to `getOutputStream`, so avoid using the deprecated method in favor of its recommended replacement.

### Testing done

CI build