### PR TITLE
[JENKINS-73875] CSP compatibility for `NewNodeConsoleNote`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.1</version>
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,14 +63,11 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.477</jenkins.version>
+        <jenkins.version>2.479</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
         <hpi.compatibleSinceVersion>2.26</hpi.compatibleSinceVersion>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <!-- TODO JENKINS-73339 until in parent POM -->
-        <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>
-        <maven.compiler.release>17</maven.compiler.release>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -80,12 +77,6 @@
                 <version>3221.ve8f7b_fdd149d</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -20,9 +20,9 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
         const toggles = e.querySelectorAll('.pipeline-show-hide .pipeline-toggle');
         const toggle = toggles[toggles.length - 1];
 
-        toggle.addEventListener('click', function(event) {
+        toggle.addEventListener('click', (event) => {
             event.preventDefault();
-            showHidePipelineSection(this);
+            showHidePipelineSection(toggle);
         });
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -18,12 +18,11 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
         // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
 
         const toggle = e.querySelector('.pipeline-toggle');
-        if (toggle) {
-            toggle.addEventListener('click', function(event) {
-                event.preventDefault();
-                showHidePipelineSection(this);
-            });
-        }
+
+        toggle.addEventListener('click', function(event) {
+            event.preventDefault();
+            showHidePipelineSection(this);
+        });
     }
 
     // The CSS rule for branch names only needs to be added once per node, so we

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -15,14 +15,13 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
     var startId = e.getAttribute('startId')
     if (startId == null || startId == nodeId) {
         e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" class="pipeline-toggle">hide</a>)</span>')
-        // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
         const toggles = e.querySelectorAll('.pipeline-show-hide .pipeline-toggle');
         const toggle = toggles[toggles.length - 1];
-
         toggle.addEventListener('click', (event) => {
             event.preventDefault();
             showHidePipelineSection(toggle);
         });
+        // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
     }
     // The CSS rule for branch names only needs to be added once per node, so we
     // check in case we are viewing the truncated log and have already processed

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -17,7 +17,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
         e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" class="pipeline-toggle">hide</a>)</span>')
         // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
 
-        const toggle = e.querySelector('.pipeline-toggle');
+        const toggle = e.querySelector('.pipeline-show-hide:last-child .pipeline-toggle');
 
         toggle.addEventListener('click', function(event) {
             event.preventDefault();

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -16,7 +16,16 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
     if (startId == null || startId == nodeId) {
         e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" class="pipeline-toggle">hide</a>)</span>')
         // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
+
+        const toggle = e.querySelector('.pipeline-toggle');
+        if (toggle) {
+            toggle.addEventListener('click', function(event) {
+                event.preventDefault();
+                showHidePipelineSection(this);
+            });
+        }
     }
+
     // The CSS rule for branch names only needs to be added once per node, so we
     // check in case we are viewing the truncated log and have already processed
     // a duplicate synthetic span element for this node.
@@ -127,12 +136,3 @@ function showHidePipelineSection(link) {
         }
     }
 }
-
-document.addEventListener('DOMContentLoaded', function() {
-    document.body.addEventListener('click', function(event) {
-        if (event.target.classList.contains('pipeline-toggle')) {
-            event.preventDefault();
-            showHidePipelineSection(event.target);
-        }
-    });
-});

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -14,7 +14,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
     var nodeId = e.getAttribute('nodeId')
     var startId = e.getAttribute('startId')
     if (startId == null || startId == nodeId) {
-        e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" onclick="showHidePipelineSection(this); return false">hide</a>)</span>')
+        e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" class="pipeline-toggle">hide</a>)</span>')
         // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
     }
     // The CSS rule for branch names only needs to be added once per node, so we
@@ -127,3 +127,12 @@ function showHidePipelineSection(link) {
         }
     }
 }
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.body.addEventListener('click', function(event) {
+        if (event.target.classList.contains('pipeline-toggle')) {
+            event.preventDefault();
+            showHidePipelineSection(event.target);
+        }
+    });
+});

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -17,7 +17,8 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
         e.innerHTML = e.innerHTML.replace(/.+/, '$&<span class="pipeline-show-hide"> (<a href="#" class="pipeline-toggle">hide</a>)</span>')
         // TODO automatically hide second and subsequent branches: namely, in case a node has the same parent as an earlier one
 
-        const toggle = e.querySelector('.pipeline-show-hide:last-child .pipeline-toggle');
+        const toggles = e.querySelectorAll('.pipeline-show-hide .pipeline-toggle');
+        const toggle = toggles[toggles.length - 1];
 
         toggle.addEventListener('click', function(event) {
             event.preventDefault();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Created a ticket in JIRA to track this issue: [JENKINS-73875](https://issues.jenkins.io/browse/JENKINS-73875)

Removed inline onClick handler from script.js to comply with Content Security Policy and replaced with event delegation.

### Testing done

STATUS QUO: No changes implemented. This is the intended functionality.

https://www.loom.com/share/da8a1ab0f1d8431e858da2ae3ac7215f?sid=2dedd5ac-eb73-472b-a0ae-11e39daff80c

NON RESTRICTIVE: This is the behavior after implementing the CSP changes. The code is working just as before and there is no regression in functionality.

https://www.loom.com/share/1f9479eeb2cf4829bdcf524d6f4d1a37?sid=cfd60732-705b-4874-9ae0-97ae1747b2d2

RESTRICTIVE: This is with CSP restrictive mode enabled. It is working correctly as intended without any issues.

https://www.loom.com/share/cad50c0d86af4e5d9ea467152a54ab08

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
