### PR TITLE
Always call `super` from `WorkflowRun.onLoad`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -556,6 +556,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @Override protected void onLoad() {
+        super.onLoad();
         try {
             synchronized (getMetadataGuard()) {
                 if (executionLoaded) {
@@ -563,8 +564,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     return;
                 }
                 boolean needsToPersist = completed == null;
-                super.onLoad();
-
                 if (Boolean.TRUE.equals(completed) && result == null) {
                     LOGGER.log(Level.FINE, "Completed build with no result set, defaulting to failure for "+this);
                     setResult(Result.FAILURE);

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -560,7 +560,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         try {
             synchronized (getMetadataGuard()) {
                 if (executionLoaded) {
-                    LOGGER.log(Level.WARNING, "Double onLoad of build "+this);
+                    LOGGER.log(Level.WARNING, "Double onLoad of build " + this, new Throwable());
                     return;
                 }
                 boolean needsToPersist = completed == null;


### PR DESCRIPTION
As of #96 and specifically 9964f7765eea8e5f179b70d135d0d0d32f6c9a79 it seems possible for `WorkflowRun.onLoad` to not call `super`. I cannot think of any justification for that. The PR description mentioned only the vague

> Lazy load changes removed protection against double onLoad calls, restoring that

Whatever that might have referred to, `Run.onLoad` would typically be idempotent, so compared to the overridden portions of this method it seems safe to unconditionally call it. Nor do I see any compelling reason to scope this within `getMetadataGuard()`, which is used for `private` fields in `WorkflowRun`.

This is my only hypothesis so far as to the cause of the errors ([CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-47223)) worked around by https://github.com/jenkinsci/junit-plugin/pull/651 & https://github.com/jenkinsci/parallel-test-executor-plugin/pull/282. I do not have access to system logs to see if _Double onLoad of build …_ was in fact logged in these cases. I hypothesize that `executionLoaded` might have been set by an earlier call to `getExecution` though I cannot think of how that could be, since `RunMap.retrieve` creates the build and calls `onLoad` before it is made available to other threads. Perhaps `LOADING_RUNS` is responsible; might some background thread with access to a `WorkflowRun.Owner` be calling `getOrNull` right after `reload` but before `onLoad`?
