### PR TITLE
Use secondary text color variable

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/script.js
@@ -53,7 +53,7 @@ Behaviour.specify("span.pipeline-new-node", 'NewNodeConsoleNote', 0, function(e)
             var branch = label.substring(8)
             var ss = document.styleSheets[0]
             // TODO https://stackoverflow.com/a/18990994/12916 does not scale well to add width: 25em; text-align: right
-            ss.insertRule('.pipeline-node-' + nodeId + '::before {content: "[' + branch.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;") + '] "; color: #9A9999; position: absolute; transform: translateX(-100%)}', ss.cssRules == null ? 0 : ss.cssRules.length)
+            ss.insertRule('.pipeline-node-' + nodeId + '::before {content: "[' + branch.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;") + '] "; color: var(--text-color-secondary); position: absolute; transform: translateX(-100%)}', ss.cssRules == null ? 0 : ss.cssRules.length)
             break
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/style.css
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/job/console/NewNodeConsoleNote/style.css
@@ -1,5 +1,5 @@
 span.pipeline-new-node {
-    color: #9A9999
+    color: var(--text-color-secondary)
 }
 span.pipeline-show-hide {
     visibility: hidden


### PR DESCRIPTION
Small one to use the secondary text colour variable over a hardcoded colour. The advantage of this is consistency with other secondary text, and also that themes can override it.

**Before**
<img width="809" alt="image" src="https://github.com/user-attachments/assets/ff5c8aac-a0f8-4936-826a-16e999a70dc9" />

**After**
<img width="814" alt="image" src="https://github.com/user-attachments/assets/49d98659-f339-471a-9b99-93331b9001a6" />

### Testing done

* Colour works as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
