### PR TITLE
Remove synchronization from `WorkflowRun.doStop`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -884,7 +884,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
     }
 
     @RequirePOST
-    public synchronized HttpResponse doStop() {
+    public HttpResponse doStop() {
         Executor e = getOneOffExecutor();
         if (e != null) {
             return e.doStop();


### PR DESCRIPTION
Revealed by a CloudBees CI test failing after https://github.com/jenkinsci/workflow-api-plugin/pull/368:

```
java.lang.AssertionError: Synchronizing on WorkflowRun before metadataGuard may cause deadlocks
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getMetadataGuard(WorkflowRun.java:219)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.doKill(WorkflowRun.java:495)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.httpKill(WorkflowRun.java:513)
	at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.doStop(WorkflowRun.java:892)
```

Here `getOneOffExecutor()` is null immediately after startup, before the build has had a chance to resume.

I am not sure if this could have happened previously in realistic timing conditions, perhaps under more exotic conditions involving unloadable builds, but anyway from code inspection `doStop` was indeed acquiring a lock in the wrong order when this clause was hit: this code path could not have worked (for years at least, did not look up how long exactly).
