### PR TITLE
`WorkflowRun.reload` must call `super.onLoad`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -557,6 +557,7 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (_execution != null) {
                     _execution.onLoad(new Owner(this));
                 }
+                super.onLoad();
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -552,10 +552,13 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
         synchronized (getMetadataGuard()) {
-            if (Boolean.TRUE.equals(completed) && executionLoaded) {
-                var _execution = execution;
-                if (_execution != null) {
-                    _execution.onLoad(new Owner(this));
+            LOGGER.fine(() -> getExternalizableId() + " completed=" + completed + " executionLoaded=" + executionLoaded);
+            if (Boolean.TRUE.equals(completed)) {
+                if (executionLoaded) {
+                    var _execution = execution;
+                    if (_execution != null) {
+                        _execution.onLoad(new Owner(this));
+                    }
                 }
                 super.onLoad();
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -468,8 +468,13 @@ public class WorkflowRunRestartTest {
             var p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
             var b = p.getBuildByNumber(1);
             var a = b.getAction(A.class);
-            assertThat("not attached in this instance", a.attached, is(0));
-            assertThat("loaded", a.loaded, is(1));
+            assertThat("after restart, not attached in this instance", a.attached, is(0));
+            assertThat("after restart, loaded", a.loaded, is(1));
+            b.reload();
+            assertThat("after restart, owner after reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));
+            a = b.getAction(A.class);
+            assertThat("after restart, not attached in this instance", a.attached, is(0));
+            assertThat("after restart, loaded", a.loaded, is(1));
         });
     }
     private static final class A extends InvisibleAction implements RunAction2 {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -80,7 +79,6 @@ import java.util.logging.Logger;
 import jenkins.model.CauseOfInterruption;
 import jenkins.model.InterruptedBuildAction;
 import jenkins.model.Jenkins;
-import jenkins.model.RunAction2;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.security.QueueItemAuthenticatorConfiguration;
 import net.sf.json.JSONArray;
@@ -619,32 +617,6 @@ public class WorkflowRunTest {
         return "    checkout(changelog:" + changelog +", poll:" + polling +
                 ", scm: [$class: 'GitSCM', branches: [[name: '*/master']], " +
                 ", userRemoteConfigs: [[url: $/" + repo.fileUrl() + "/$]]])\n";
-    }
-
-    @Test public void reloadOwnerAndActions() throws Exception {
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("", true));
-        WorkflowRun b = r.buildAndAssertSuccess(p);
-        var a = new A();
-        b.addAction(a);
-        b.save();
-        assertThat("right owner before reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));
-        assertThat("attached once", a.attached, is(1));
-        assertThat("not yet loaded", a.loaded, is(0));
-        b.reload();
-        assertThat("right owner after reload", b.getExecution().getOwner(), is(b.asFlowExecutionOwner()));
-        a = b.getAction(A.class);
-        assertThat("not attached in this instance", a.attached, is(0));
-        assertThat("loaded", a.loaded, is(1));
-    }
-    private static final class A extends InvisibleAction implements RunAction2 {
-        transient volatile int attached, loaded;
-        @Override public void onAttached(Run<?, ?> r) {
-            attached++;
-        }
-        @Override public void onLoad(Run<?, ?> r) {
-            loaded++;
-        }
     }
 
     // This test is to ensure that the shortDescription on the CancelCause is escaped properly on summary.jelly


### PR DESCRIPTION
Amending #472 as I think I finally tracked down the problem with `TestResultAction` that I was trying without success to fix in #485. Ultimately this feels like a bug, or at least an anomaly, in core since https://github.com/jenkinsci/jenkins/commit/50f7aa3b3399caef7f2da3131ce52f466556e305 defined the `Run.reload` method with a vague comment saying that `onLoad` was not to be called since `reload` would be used from one `Run` constructor overload (which it is; in this PR that call site will not activate the patched behavior) but also that some unidentified uses do not want to be called multiple times. The latter part makes no sense, since this is on a fresh `RunAction2` instance each time, and due to lazy loading that might already be true. This only seems to affect CloudBees CI, which calls this method in HA mode, since I am not aware of any call to `Run.reload` except via the load-from-disk constructor.