### PR TITLE
Fix a deadlock between `WorkflowRun#save` and `WorkflowRun#reload`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -556,22 +556,18 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
 
         // super.reload() forces result to be FAILURE, so working around that
         new XmlFile(XSTREAM,new File(getRootDir(),"build.xml")).unmarshal(this);
-        synchronized (getMetadataGuard()) {
-            LOGGER.fine(() -> getExternalizableId() + " completed=" + completed + " executionLoaded=" + executionLoaded + " loaded=" + loaded);
-            if (Boolean.TRUE.equals(completed)) {
-                if (executionLoaded) {
-                    var _execution = execution;
-                    if (_execution != null) {
-                        synchronized (this) {
-                            _execution.onLoad(new Owner(this));
-                        }
-                    }
-                }
+        synchronized (this) {
+            var _completed = completed;
+            var _executionLoaded = executionLoaded;
+            var _execution = execution;
+            LOGGER.fine(() -> getExternalizableId() + " completed=" + _completed + " executionLoaded=" + _executionLoaded);
+            if (Boolean.TRUE.equals(_completed) && _executionLoaded && _execution != null) {
+                _execution.onLoad(new Owner(this));
             }
-            if (loaded) {
-                super.onLoad();
-            } // else from WorkflowRun(WorkflowJob, File), and RunMap.retrieve will call onLoad
         }
+        if (loaded) {
+            super.onLoad();
+        } // else from WorkflowRun(WorkflowJob, File), and RunMap.retrieve will call onLoad
     }
 
     @Override protected void onLoad() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -562,7 +562,9 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (executionLoaded) {
                     var _execution = execution;
                     if (_execution != null) {
-                        _execution.onLoad(new Owner(this));
+                        synchronized (this) {
+                            _execution.onLoad(new Owner(this));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Ensure locking order

metadataGuard > WorkflowRun > CpsFlowExecution

```
"some-thread" id=130 (0x82) state=BLOCKED cpu=84%
    - waiting to lock <0x54046fbb> (a org.jenkinsci.plugins.workflow.job.WorkflowRun)
      owned by "Running CpsFlowExecution[Owner[some-project/1:some-project #1]]" id=27474 (0x6b52)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1252)
    at hudson.BulkChange.commit(BulkChange.java:98)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1557)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x000000080191daa0.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:146)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:123)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:751)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:815)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.reload(WorkflowRun.java:561)
[...]

"Running CpsFlowExecution[Owner[some-project/1:some-project #1]]" id=27474 (0x6b52) state=BLOCKED cpu=64%
    - waiting to lock <0x29b5111b> (a org.jenkinsci.plugins.workflow.cps.CpsFlowExecution)
      owned by "some-thread" id=130 (0x82)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution$ConverterImpl.marshal(CpsFlowExecution.java:1737)
    at hudson.util.XStream2$AssociatedConverterImpl.marshal(XStream2.java:556)
    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:83)
    at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:283)
    at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:270)
    at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:241)
    at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:174)
    at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:226)
    at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:163)
    at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:68)
    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:59)
    at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:44)
    at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:83)
    at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
    at com.thoughtworks.xstream.XStream.marshal(XStream.java:1307)
    at com.thoughtworks.xstream.XStream.marshal(XStream.java:1296)
    at com.thoughtworks.xstream.XStream.toXML(XStream.java:1269)
    at hudson.XmlFile.write(XmlFile.java:216)
    at PluginClassLoader for workflow-support//org.jenkinsci.plugins.workflow.support.PipelineIOUtils.writeByXStream(PipelineIOUtils.java:30)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.save(WorkflowRun.java:1253)
[...]
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
