### PR TITLE
JENKINS-74908 Stop the previous build immediately

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -345,8 +345,9 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                 if (prev != null && prev.isBuilding()) {
                     Executor e = prev.getExecutor();
                     if (e != null) {
-                        e.interrupt(Result.NOT_BUILT, new DisableConcurrentBuildsJobProperty.CancelledCause(this));
+                        e.interrupt(Result.ABORTED, new DisableConcurrentBuildsJobProperty.CancelledCause(this));
                     }
+                    prev.doKill();
                 }
                 // Not bothering to look for other older builds in progress, since once we turn this on, going forward there should be at most one.
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -641,8 +641,8 @@ public class WorkflowRunTest {
         b2.save();
         SemaphoreStep.waitForStart("hang/2", b2);
 
-        // Check that the first build has been aborted with a status of 'NOT_BUILT'
-        r.assertBuildStatus(Result.NOT_BUILT, r.waitForCompletion(b1));
+        // Check that the first build has been aborted with a status of 'ABORTED'
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b1));
 
         // Kill the second build, then delete it and check it has been deleted
         b2.doKill();

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobPropertyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/properties/DisableConcurrentBuildsJobPropertyTest.java
@@ -140,7 +140,7 @@ public class DisableConcurrentBuildsJobPropertyTest {
         SemaphoreStep.waitForStart("run/5", b5);
         WorkflowRun b6 = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("run/6", b6);
-        r.assertBuildStatus(Result.NOT_BUILT, r.waitForCompletion(b5));
+        r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b5));
         InterruptedBuildAction iba = b5.getAction(InterruptedBuildAction.class);
         assertNotNull(iba);
         assertEquals(1, iba.getCauses().size());


### PR DESCRIPTION
This change ensures that previous builds are aborted immediately as expected so new builds don't need to handle possible clutter. Possibly fixes jenkinsci/bitbucket-branch-source-plugin#768 as well.

### Testing done

I tested this in a local Jenkins instance by running the same job twice concurrently and having the first build being aborted immediately as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

