### PR TITLE
Simplified locking in `getExecution`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -703,10 +703,8 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
      * @return non-null after the flow has started, even after finished (but may be null temporarily when about to start, or if starting failed)
      */
     public @CheckForNull FlowExecution getExecution() {
-        if (executionLoaded || execution == null) {  // Avoids highly-contended synchronization on run
-            return execution;
-        } else {  // Try to lazy-load execution
-            synchronized (this) {  // Double-checked locking rendered safe by use of volatile field
+        // Try to lazy-load execution
+            synchronized (getMetadataGuard()) {
                 FlowExecution fetchedExecution = execution;
                 if (executionLoaded || fetchedExecution == null) {
                     return fetchedExecution;
@@ -763,7 +761,6 @@ public final class WorkflowRun extends Run<WorkflowJob,WorkflowRun> implements F
                     return null;
                 }
             }
-        }
     }
 
     /**


### PR DESCRIPTION
Amends #97. A deadlock was reported

<details>
<summary>Redacted dump</summary>

```
…"jenkins.util.Timer [#4]" id=63 (0x3f) state=BLOCKED cpu=86%
    - waiting to lock <0x7e3b640a> (a org.jenkinsci.plugins.workflow.job.WorkflowRun)
      owned by "Jetty (winstone)-397" id=397 (0x18d)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:709)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.onLoad(WorkflowRun.java:591)
    at hudson.model.RunMap.retrieve(RunMap.java:273)
    at hudson.model.RunMap.retrieve(RunMap.java:65)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:703)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.load(AbstractLazyLoadRunMap.java:685)
    at jenkins.model.lazy.AbstractLazyLoadRunMap.getByNumber(AbstractLazyLoadRunMap.java:579)
    at jenkins.model.lazy.LazyBuildMixIn.getBuildByNumber(LazyBuildMixIn.java:239)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowJob.getBuildByNumber(WorkflowJob.java:233)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowJob.getBuildByNumber(WorkflowJob.java:104)
    at hudson.model.Run.fromExternalizableId(Run.java:2472)
    at …

"Jetty (winstone)-397" id=397 (0x18d) state=BLOCKED cpu=84%
    - waiting to lock <0x157e1ed5> (a java.lang.Object)
      owned by "jenkins.util.Timer [#4]" id=63 (0x3f)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.finish(WorkflowRun.java:644)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1076)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:146)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.setNewHead(FlowHead.java:123)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:749)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$GraphL.onNewHead(WorkflowRun.java:1074)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.notifyListeners(CpsFlowExecution.java:1542)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.lambda$notifyNewHead$0(FlowHead.java:164)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead$$Lambda/0x00007f0859a1e428.run(Unknown Source)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.notifyNewHead(FlowHead.java:169)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.FlowHead.newStartNode(FlowHead.java:118)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.createPlaceholderNodes(CpsFlowExecution.java:744)
    at PluginClassLoader for workflow-cps//org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.onLoad(CpsFlowExecution.java:812)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun.getExecution(WorkflowRun.java:727)
    at PluginClassLoader for workflow-job//org.jenkinsci.plugins.workflow.job.WorkflowRun$Owner.get(WorkflowRun.java:997)
    at …
```

</details>

I am not sure what was causing the recursion in `createPlaceholderNodes` (in another case a `StackOverflowError` was observed). https://github.com/jenkinsci/workflow-cps-plugin/pull/1008 allows this whole mechanism to be disabled.

At any rate, the immediate problem seems to be that `getExecution` was locking `this` yet could ultimately call `finish` which locks `metadataGuard`, and the Javadoc is clear that you need to lock the guard first (if not solely).

No idea how to test this.
