### PR TITLE
Stop adding `TimingAction` in `WorkflowRun$GraphL` and let `workflow-cps` handle it instead

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -95,7 +95,6 @@ import jenkins.scm.RunWithSCM;
 import jenkins.util.SystemProperties;
 import jenkins.util.Timer;
 import org.jenkinsci.plugins.workflow.FilePathUtils;
-import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.flow.BlockableResume;
 import org.jenkinsci.plugins.workflow.flow.DurabilityHintProvider;
 import org.jenkinsci.plugins.workflow.flow.FlowCopier;


### PR DESCRIPTION
Requires https://github.com/jenkinsci/workflow-cps-plugin/pull/1052 to be release first, and then when this is released, users need to make sure that `workflow-cps` is updated either before or at the same time that they update to this PR, otherwise `FlowStartNode` will end up without a `TimingAction`.

While trying to write tests for https://github.com/jenkinsci/workflow-cps-plugin/pull/1052 and https://github.com/jenkinsci/workflow-job-plugin/pull/547, I realized that the way that `WorkflowRun$GraphL` adds `TimingAction` is almost totally redundant due to `FlowHead.setNewHead` already adding `TimingAction`. The `TimingAction` addition logic was added to `FlowHead.setNewHead` in https://github.com/jenkinsci/workflow-cps-plugin/pull/188, and then the `if` was added to the logic here in https://github.com/jenkinsci/workflow-job-plugin/pull/75 when picking up the `workflow-cps` PR in tests to avoid adding a second `TimingAction`.

The logic in `workflow-job` is almost totally unused now, since `setNewHead` is responsible for calling `notifyNewHead`, which is what notifies `GraphListener`s, so it already handles almost all nodes. The only case that still matters is `FlowStartNode`, because `newStartNode` is separate from `setNewHead`, and `newStartNode` doesn't add `TimingAction`. https://github.com/jenkinsci/workflow-cps-plugin/pull/1052 now handles `FlowStartNode` directly as of https://github.com/jenkinsci/workflow-cps-plugin/pull/1052/commits/42419079a10571f28e5387c546f00c7aa8c9892b.

### Testing done

I tested this PR against the new automated tests in https://github.com/jenkinsci/workflow-cps-plugin/pull/1052, to ensure that with this PR and without the changes to `FlowHead.newStartNode` in that PR, the new test `CpsFlowExecutionTest.timingActionAlwaysAdded` fails. (I could duplicate the same test here, but it seems clearest to test over in `workflow-cps` since that plugin is the one adding `TimingAction`.)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
