### PR TITLE
Add draft ItemConfigurator support for WorkflowJob

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,15 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,10 @@
       <artifactId>configuration-as-code</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <scope>compile</scope>

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/PipelineItemConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/PipelineItemConfigurator.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.workflow.job;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.ItemConfigurator;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+
+import java.io.IOException;
+
+@Extension
+public class PipelineItemConfigurator implements ItemConfigurator<WorkflowJob> {
+
+	@Override
+	public String getName() {
+		return "pipeline";
+	}
+
+	@Override
+	public Class<WorkflowJob> getTarget() {
+		return WorkflowJob.class;
+	}
+
+	@Override
+	public WorkflowJob configure(String name, CNode config, ConfigurationContext context) throws ConfiguratorException {
+		try {
+			Jenkins jenkins = Jenkins.get();
+			WorkflowJob job = (WorkflowJob) jenkins.getItem(name);
+
+			if (job == null) {
+				job = jenkins.createProject(WorkflowJob.class, name);
+			}
+
+			Mapping mapping = config.asMapping();
+
+			if (mapping.containsKey("description")) {
+				job.setDescription(mapping.getScalarValue("description"));
+			}
+
+			CNode definitionNode = mapping.get("definition");
+			if (definitionNode != null) {
+				Mapping defMapping = definitionNode.asMapping();
+				if (defMapping.containsKey("cps")) {
+					String script = defMapping.get("cps").asMapping().getScalarValue("script");
+					job.setDefinition(new CpsFlowDefinition(script, true));
+				}
+			}
+
+			job.save();
+			return job;
+
+		} catch (IOException | Descriptor.FormException e) {
+			throw new ConfiguratorException("Failed to configure pipeline: " + name, e);
+		}
+	}
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/PipelineItemConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/PipelineItemConfiguratorTest.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.workflow.job;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PipelineItemConfiguratorTest {
+
+	@Rule
+	public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+	@Test
+	@ConfiguredWithCode("create-pipeline.yaml")
+	public void shouldCreateNewPipeline() {
+		WorkflowJob job = (WorkflowJob) Jenkins.get().getItem("my-new-pipeline");
+
+		assertNotNull("Pipeline job should have been created by JCasC", job);
+		assertEquals("A brand new pipeline created by JCasC", job.getDescription());
+
+		assertTrue("Definition should be CpsFlowDefinition", job.getDefinition() instanceof CpsFlowDefinition);
+		CpsFlowDefinition definition = (CpsFlowDefinition) job.getDefinition();
+		assertEquals("node { echo 'Hello, JCasC!' }", definition.getScript());
+		assertTrue("Sandbox should be true", definition.isSandbox());
+	}
+
+	@Test
+	public void shouldUpdateExistingPipeline() throws Exception {
+		WorkflowJob existingJob = j.jenkins.createProject(WorkflowJob.class, "existing-pipeline");
+		existingJob.setDescription("Old Description");
+		existingJob.setDefinition(new CpsFlowDefinition("node { echo 'Old script' }", false));
+
+		ConfigurationAsCode.get().configure(
+			Objects.requireNonNull(getClass().getResource("update-pipeline.yaml")).toExternalForm()
+		);
+
+		WorkflowJob updatedJob = (WorkflowJob) Jenkins.get().getItem("existing-pipeline");
+
+		assertNotNull(updatedJob);
+		assertEquals("Updated description via JCasC", updatedJob.getDescription());
+
+		CpsFlowDefinition definition = (CpsFlowDefinition) updatedJob.getDefinition();
+		assertEquals("node { echo 'Updated script!' }", definition.getScript());
+		assertTrue("Sandbox should be reset to true", definition.isSandbox());
+	}
+}

--- a/src/test/resources/org/jenkinsci/plugins/workflow/job/create-pipeline.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/job/create-pipeline.yaml
@@ -1,0 +1,7 @@
+items:
+  - pipeline:
+      name: "my-new-pipeline"
+      description: "A brand new pipeline created by JCasC"
+      definition:
+        cps:
+          script: "node { echo 'Hello, JCasC!' }"

--- a/src/test/resources/org/jenkinsci/plugins/workflow/job/update-pipeline.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/workflow/job/update-pipeline.yaml
@@ -1,0 +1,7 @@
+items:
+  - pipeline:
+      name: "existing-pipeline"
+      description: "Updated description via JCasC"
+      definition:
+        cps:
+          script: "node { echo 'Updated script!' }"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

See https://github.com/jenkinsci/configuration-as-code-plugin/pull/2881

Add a draft `PipelineItemConfigurator` implementation demonstrating how the proposed `ItemConfigurator` extension point can be used by the Workflow Job plugin to create and configure `WorkflowJob` instances through JCasC. This proof of concept supports configuring a job's name, description, and an inline CPS pipeline definition (`CpsFlowDefinition`), illustrating that the API can be extended beyond freestyle jobs. Example configuration:

```
items:
  - pipeline:
      name: "my-ci-pipeline"
      description: "Builds the project"
      definition:
        cps:
          script: |
            node {
              echo 'Hello Pipeline!'
            }
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
