### PR TITLE
Populate `SCM.buildEnvironment` in build variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/SCMEnvironmentContributor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/SCMEnvironmentContributor.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.job;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+
+/**
+ * Binds SCM variables to the build environment.
+ * Note that only the first checkout is bound in this way;
+ * in general the return value of {@code SCMStep} may be used.
+ */
+@Extension
+public final class SCMEnvironmentContributor extends EnvironmentContributor {
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener)
+            throws IOException, InterruptedException {
+        if (r instanceof WorkflowRun wr) {
+            var scms = wr.getSCMs();
+            if (!scms.isEmpty()) {
+                scms.get(0).buildEnvironment(r, envs);
+            }
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunTest.java
@@ -139,11 +139,13 @@ class WorkflowRunTest {
     private final LogRecorder logging = new LogRecorder().record(FlowExecutionList.class, Level.FINE);
     private JenkinsRule r;
     private GitSampleRepoRule sampleRepo;
+    private GitSampleRepoRule sampleRepo2;
 
     @BeforeEach
-    void beforeEach(JenkinsRule rule, GitSampleRepoRule repo) {
+    void beforeEach(JenkinsRule rule, GitSampleRepoRule repo, GitSampleRepoRule repo2) {
         r = rule;
         sampleRepo = repo;
+        sampleRepo2 = repo2;
     }
 
     @Test
@@ -651,6 +653,41 @@ class WorkflowRunTest {
         List<SCM> checkouts = b.getSCMs();
         assertEquals(1, checkouts.size());
         assertEquals(GitSCM.class, checkouts.get(0).getClass());
+    }
+
+    @Test
+    void scmEnvVars() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("f", "content 1");
+        sampleRepo.git("add", "f");
+        sampleRepo.git("commit", "--message=1");
+        var commit1 = sampleRepo.head();
+        sampleRepo2.init();
+        sampleRepo2.write("f", "content 2");
+        sampleRepo2.git("add", "f");
+        sampleRepo2.git("commit", "--message=2");
+        var p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("""
+            node {
+              dir('repo') {
+                git REPO
+              }
+              dir('repo2') {
+                git REPO2
+              }
+              echo "recorded commit is $GIT_COMMIT"
+            }
+            """, true));
+        p.addProperty(new ParametersDefinitionProperty(
+                new StringParameterDefinition("REPO"), new StringParameterDefinition("REPO2")));
+        var b = p.scheduleBuild2(
+                        0,
+                        new ParametersAction(
+                                new StringParameterValue("REPO", sampleRepo.toString()),
+                                new StringParameterValue("REPO2", sampleRepo2.toString())))
+                .get();
+        r.assertBuildStatusSuccess(b);
+        r.assertLogContains("recorded commit is " + commit1, b);
     }
 
     @Issue("JENKINS-61415")


### PR DESCRIPTION
Was originally going to do this in `workflow-scm-step` (prepared https://github.com/jenkinsci/workflow-scm-step-plugin/pull/271 for that purpose) but it turned out to require a `WorkflowRun` method not exported via any API, so easiest to just do it here instead.

[CloudBees-internal link](https://cloudbees.atlassian.net/browse/BEE-74199)