### PR TITLE
Avoid racing workflow execution reads

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -1200,9 +1200,10 @@ public final class WorkflowRun extends Run<WorkflowJob, WorkflowRun>
                         .schedule(
                                 () -> {
                                     synchronized (getMetadataGuard()) {
+                                        FlowExecution currentExecution = execution;
                                         finish(
                                                 ((FlowEndNode) node).getResult(),
-                                                execution != null ? execution.getCauseOfFailure() : null);
+                                                currentExecution != null ? currentExecution.getCauseOfFailure() : null);
                                     }
                                 },
                                 1,


### PR DESCRIPTION
## Summary

- snapshot the volatile workflow execution before checking it for a recorded failure cause
- avoid the second field read that the upgraded plugin parent correctly reports as a possible null dereference

## Why

Dependabot PR #784 upgrades the Jenkins plugin parent to `6.2221.va_045130417c9`. Its SpotBugs gate reports `NP_NULL_ON_SOME_PATH` in `FailOnLoadListener`: `execution` is read once for the null check and again for `getCauseOfFailure()`, so the second read is not protected by the first.

Keeping one local snapshot makes the check and dereference consistent while preserving the existing fallback to a null failure cause. This companion PR targets the Dependabot branch so the parent update and its analyzer repair can be reviewed together.

## Verification

- reproduced the single SpotBugs finding on the unmodified Dependabot commit
- `mvn -B -ntp -DskipTests verify` — compilation, Enforcer, SpotBugs (zero findings), and Spotless passed
- `mvn -B -ntp -Dtest=WorkflowRunRestartTest#flowExecutionListener test` — passed
- a full-suite attempt completed the 68 injected tests with zero failures before the local host exhausted disk during later Jenkins harness setup; the complete suite is not claimed as passing
- `git diff --check`

JAIPilot Remote received an exact tracked-source archive for commit `20b41f8b3350060c50b89858845610a1a86ad769`, but `repo.jenkins-ci.org` reset the parent-POM download; the workspace was destroyed and no remote test result is claimed.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
