### PR TITLE
Fail `onLoad` if a build never actually started to begin with

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -672,7 +672,7 @@ public final class WorkflowRun extends Run<WorkflowJob, WorkflowRun>
                     } else { // Execution nulled due to a critical failure, explicitly mark completed
                         completed = Boolean.TRUE;
                     }
-                } else if (execution == null) {
+                } else if (execution == null && !Boolean.TRUE.equals(completed)) {
                     getListener().getLogger().println("Build never fully started; cancelling");
                     completed = true;
                     needsToPersist = true;

--- a/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java
@@ -673,7 +673,12 @@ public final class WorkflowRun extends Run<WorkflowJob, WorkflowRun>
                         completed = Boolean.TRUE;
                     }
                 } else if (execution == null) {
-                    completed = Boolean.TRUE;
+                    getListener().getLogger().println("Build never fully started; cancelling");
+                    completed = true;
+                    needsToPersist = true;
+                    var suddenDeath = new FlowInterruptedException(Result.ABORTED, true);
+                    Timer.get().submit(() -> finish(Result.ABORTED, suddenDeath));
+                    getSettableExecutionPromise().setException(suddenDeath);
                 }
                 if (needsToPersist && completed) {
                     try {

--- a/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/job/WorkflowRunRestartTest.java
@@ -42,10 +42,13 @@ import hudson.model.InvisibleAction;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import java.io.IOException;
 import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
 import java.util.logging.Level;
 import jenkins.model.RunAction2;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -300,6 +303,40 @@ class WorkflowRunRestartTest {
             WorkflowRun b = p.getLastBuild();
             assertFalse(b.isBuilding(), "Build should be completed");
         });
+    }
+
+    @Test
+    void exitedWhileStarting() throws Throwable {
+        sessions.then(r -> {
+            WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("// never gets here", true));
+            p.scheduleBuild2(0).waitForStart();
+            ExtensionList.lookupSingleton(BlockOnStarted.class).starting.acquire();
+        });
+        sessions.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getLastBuild();
+            assertFalse(b.isBuilding(), "Build should be completed");
+            r.assertBuildStatus(Result.ABORTED, b);
+            r.assertLogContains("never fully started", b);
+        });
+    }
+
+    @TestExtension("exitedWhileStarting")
+    public static final class BlockOnStarted extends RunListener<WorkflowRun> {
+        final Semaphore starting = new Semaphore(0);
+
+        @Override
+        public void onStarted(WorkflowRun r, TaskListener listener) {
+            try {
+                listener.getLogger().println("Declining to start");
+                r.save();
+                starting.release(1);
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (IOException | InterruptedException x) {
+                assert false : x;
+            }
+        }
     }
 
     private boolean hasTermOrKillLink(JenkinsRule r, WorkflowRun b, String termOrKill) throws Exception {


### PR DESCRIPTION
Idiom similar to that in #753, amending a535449cb96ab102dbd3bec4ad9e18fe5312b3ab from #93. A variant of #167 where `WorkflowRun.run` was not interrupted—rather, the controller simply exited without it completing, because `FlowDefinition.create` took too long.

We could also try to reschedule the build, though doing this correctly may be tricky (consider **Replay**, `SCMRevisionAction`, etc.), and it is not necessarily clear that such behavior would be desirable.